### PR TITLE
Fix academics payload and restore campus/carefuse static pages

### DIFF
--- a/academics/index.txt
+++ b/academics/index.txt
@@ -1,9 +1,447 @@
-DISABLED RSC PAYLOAD - academics (client serialized payload intentionally removed to keep static HTML authoritative)
-2:I[5878,["878","static/chunks/878-a2053ba011a8f515.js","260","static/chunks/app/academics/page-8fd6ebd0587d27ab.js"],"Image"]
-3:I[4707,[],""]
-4:I[6423,[],""]
-5:I[3064,["972","static/chunks/972-e6acae3a74adc8b1.js","878","static/chunks/878-a2053ba011a8f515.js","185","static/chunks/app/layout-96060b751e953699.js"],"default"]
-6:I[2972,["972","static/chunks/972-e6acae3a74adc8b1.js","878","static/chunks/878-a2053ba011a8f515.js","931","static/chunks/app/page-7082a7a560f40c4d.js"],""]
-0:["TvnfXHU6nbvB6OIZi7NfN",[[["",{"children":["academics",{"children":["__PAGE__",{}]}]},"$undefined","$undefined",true],["",{"children":["academics",{"children":["__PAGE__",{},[["$L1",["$","div",null,{"className":"py-20 bg-white","children":["$","div",null,{"className":"max-w-7xl mx-auto px-4 sm:px-6 lg:px-8","children":[["$","div",null,{"className":"text-center mb-16","children":[["$","h1",null,{"className":"text-4xl sm:text-5xl font-bold text-gray-900 mb-6","children":"Academic Journey"}],["$","p",null,{"className":"text-xl text-gray-600 max-w-3xl mx-auto","children":"Building a strong foundation in computer engineering with focus on robotics, AI, and embedded systems"}]]}],["$","section",null,{"className":"mb-20","children":["$","div",null,{"className":"rounded-lg border border-gray-200 shadow-sm hover:shadow-md hover:border-gray-300 transition-all duration-200 bg-gradient-to-br from-vt-maroon to-vt-orange text-white max-w-4xl mx-auto","children":[["$","div",null,{"className":"p-6 pb-4","children":["$","div",null,{"className":"flex flex-col lg:flex-row items-center justify-between space-y-6 lg:space-y-0","children":[["$","div",null,{"className":"flex items-center space-x-4","children":[["$","div",null,{"className":"w-16 h-16 bg-white/20 rounded-lg flex items-center justify-center","children":["$","svg",null,{"xmlns":"http://www.w3.org/2000/svg","width":24,"height":24,"viewBox":"0 0 24 24","fill":"none","stroke":"currentColor","strokeWidth":2,"strokeLinecap":"round","strokeLinejoin":"round","className":"lucide lucide-graduation-cap w-8 h-8 text-white","aria-hidden":"true","children":[["$","path","j76jl0",{"d":"M21.42 10.922a1 1 0 0 0-.019-1.838L12.83 5.18a2 2 0 0 0-1.66 0L2.6 9.08a1 1 0 0 0 0 1.832l8.57 3.908a2 2 0 0 0 1.66 0z"}],["$","path","1lu8f3",{"d":"M22 10v6"}],["$","path","1r8lef",{"d":"M6 12.5V16a6 3 0 0 0 12 0v-3.5"}],"$undefined"]}]}],["$","div",null,{"children":[["$","h3",null,{"className":"font-semibold mb-2 text-white text-3xl","children":"B.S. Computer Engineering (Software Systems)"}],["$","p",null,{"className":"text-white/90 text-xl","children":"Virginia Tech"}]]}]]}],["$","div",null,{"className":"flex-shrink-0","children":["$","$L2",null,{"src":"/images/bradley_dept_logo.jpg","alt":"VT Bradley Department of Electrical and Computer Engineering","width":280,"height":180,"className":"rounded-lg bg-white p-3"}]}]]}]}],["$","div",null,{"className":"px-6 pb-6","children":["$","div",null,{"className":"grid grid-cols-1 md:grid-cols-2 gap-8","children":[["$","div",null,{"children":[["$","h3",null,{"className":"text-xl font-semibold mb-4 flex items-center","children":[["$","svg",null,{"xmlns":"http://www.w3.org/2000/svg","width":24,"height":24,"viewBox":"0 0 24 24","fill":"none","stroke":"currentColor","strokeWidth":2,"strokeLinecap":"round","strokeLinejoin":"round","className":"lucide lucide-award w-5 h-5 mr-2","aria-hidden":"true","children":[["$","path","1yiouv",{"d":"m15.477 12.89 1.515 8.526a.5.5 0 0 1-.81.47l-3.58-2.687a1 1 0 0 0-1.197 0l-3.586 2.686a.5.5 0 0 1-.81-.469l1.514-8.526"}],["$","circle","1vp47v",{"cx":"12","cy":"8","r":"6"}],"$undefined"]}],"Academic Performance"]}],["$","div",null,{"className":"space-y-2","children":[["$","div",null,{"className":"flex justify-between","children":[["$","span",null,{"children":"GPA:"}],["$","span",null,{"className":"font-bold","children":"3.8/4.0"}]]}],["$","div",null,{"className":"text-white/90","children":"Accelerated UG-to-MS coursework initiated; 3 years of research in robotics/autonomy."}]]}]]}],["$","div",null,{"children":[["$","h3",null,{"className":"text-xl font-semibold mb-4 flex items-center","children":[["$","svg",null,{"xmlns":"http://www.w3.org/2000/svg","width":24,"height":24,"viewBox":"0 0 24 24","fill":"none","stroke":"currentColor","strokeWidth":2,"strokeLinecap":"round","strokeLinejoin":"round","className":"lucide lucide-book-open w-5 h-5 mr-2","aria-hidden":"true","children":[["$","path","1akyts",{"d":"M12 7v14"}],["$","path","ruj8y",{"d":"M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z"}],"$undefined"]}],"Specialization"]}],["$","p",null,{"className":"text-white/90","children":"Software Systems track with emphasis on embedded systems, machine learning, and robotics applications. Accelerated undergraduate-to-master's coursework initiated."}]]}]]}]}]]}]}],["$","section",null,{"className":"mb-20","children":[["$","h2",null,{"className":"text-3xl font-bold text-gray-900 mb-12 text-center","children":"Research Experience"}],["$","div",null,{"className":"grid grid-cols-1 md:grid-cols-2 gap-8","children":[["$","div",null,{"className":"bg-white rounded-lg border border-gray-200 shadow-sm hover:border-gray-300 group hover:shadow-lg transition-all duration-200","children":[["$","div",null,{"className":"p-6 pb-4","children":["$","div",null,{"className":"flex items-start space-x-3","children":[["$","div",null,{"className":"w-10 h-10 bg-blue-500 rounded-lg flex items-center justify-center flex-shrink-0 group-hover:scale-110 transition-transform","children":["$","svg",null,{"xmlns":"http://www.w3.org/2000/svg","width":24,"height":24,"viewBox":"0 0 24 24","fill":"none","stroke":"currentColor","strokeWidth":2,"strokeLinecap":"round","strokeLinejoin":"round","className":"lucide lucide-lightbulb w-5 h-5 text-white","aria-hidden":"true","children":[["$","path","1gvzjb",{"d":"M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5"}],["$","path","x1upvd",{"d":"M9 18h6"}],["$","path","ceow96",{"d":"M10 22h4"}],"$undefined"]}]}],["$","div",null,{"children":[["$","h3",null,{"className":"font-semibold text-gray-900 mb-2 text-lg","children":"Terrestrial Robotics (TREC Lab)"}],["$","p",null,{"className":"leading-relaxed text-vt-maroon font-medium","children":"Aug 2022–May 2024"}]]}]]}]}],["$","div",null,{"className":"px-6 pb-6","children":["$","p",null,{"className":"text-gray-700","children":"Sensor integration, CAN messaging, encoder interfaces"}]}]]}],["$","div",null,{"className":"bg-white rounded-lg border border-gray-200 shadow-sm hover:border-gray-300 group hover:shadow-lg transition-all duration-200","children":[["$","div",null,{"className":"p-6 pb-4","children":["$","div",null,{"className":"flex items-start space-x-3","children":[["$","div",null,{"className":"w-10 h-10 bg-teal-500 rounded-lg flex items-center justify-center flex-shrink-0 group-hover:scale-110 transition-transform","children":["$","svg",null,{"xmlns":"http://www.w3.org/2000/svg","width":24,"height":24,"viewBox":"0 0 24 24","fill":"none","stroke":"currentColor","strokeWidth":2,"strokeLinecap":"round","strokeLinejoin":"round","className":"lucide lucide-lightbulb w-5 h-5 text-white","aria-hidden":"true","children":[["$","path","1gvzjb",{"d":"M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5"}],["$","path","x1upvd",{"d":"M9 18h6"}],["$","path","ceow96",{"d":"M10 22h4"}],"$undefined"]}]}],["$","div",null,{"children":[["$","h3",null,{"className":"font-semibold text-gray-900 mb-2 text-lg","children":"Marine Autonomy (CMAR)"}],["$","p",null,{"className":"leading-relaxed text-vt-maroon font-medium","children":"Aug 2024–Present"}]]}]]}]}],["$","div",null,{"className":"px-6 pb-6","children":["$","p",null,{"className":"text-gray-700","children":"Bayesian obstacle detection, sonar systems, ROS integration"}]}]]}]]}]]}],["$","section",null,{"className":"mb-20","children":[["$","h2",null,{"className":"text-3xl font-bold text-gray-900 mb-12 text-center","children":"Academic Leadership"}],["$","div",null,{"className":"grid grid-cols-1 md:grid-cols-2 gap-8","children":[["$","div",null,{"className":"bg-white rounded-lg border border-gray-200 shadow-sm hover:border-gray-300 group hover:shadow-lg transition-all duration-200","children":[["$","div",null,{"className":"p-6 pb-4","children":["$","div",null,{"className":"flex items-start space-x-3","children":[["$","div",null,{"className":"w-10 h-10 bg-green-500 rounded-lg flex items-center justify-center flex-shrink-0 group-hover:scale-110 transition-transform","children":["$","svg",null,{"xmlns":"http://www.w3.org/2000/svg","width":24,"height":24,"viewBox":"0 0 24 24","fill":"none","stroke":"currentColor","strokeWidth":2,"strokeLinecap":"round","strokeLinejoin":"round","className":"lucide lucide-users w-5 h-5 text-white","aria-hidden":"true","children":[["$","path","1yyitq",{"d":"M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"}],["$","path","16gr8j",{"d":"M16 3.128a4 4 0 0 1 0 7.744"}],["$","path","kshegd",{"d":"M22 21v-2a4 4 0 0 0-3-3.87"}],["$","circle","nufk8",{"cx":"9","cy":"7","r":"4"}],"$undefined"]}]}],["$","div",null,{"children":["$","h3",null,{"className":"font-semibold text-gray-900 mb-2 text-lg","children":"ECE 2564 Undergraduate Teaching Assistant"}]}]]}]}],["$","div",null,{"className":"px-6 pb-6","children":["$","p",null,{"className":"leading-relaxed text-gray-700","children":"Assisted students with embedded systems programming and hardware design"}]}]]}],["$","div",null,{"className":"bg-white rounded-lg border border-gray-200 shadow-sm hover:border-gray-300 group hover:shadow-lg transition-all duration-200","children":[["$","div",null,{"className":"p-6 pb-4","children":["$","div",null,{"className":"flex items-start space-x-3","children":[["$","div",null,{"className":"w-10 h-10 bg-purple-500 rounded-lg flex items-center justify-center flex-shrink-0 group-hover:scale-110 transition-transform","children":["$","svg",null,{"xmlns":"http://www.w3.org/2000/svg","width":24,"height":24,"viewBox":"0 0 24 24","fill":"none","stroke":"currentColor","strokeWidth":2,"strokeLinecap":"round","strokeLinejoin":"round","className":"lucide lucide-users w-5 h-5 text-white","aria-hidden":"true","children":[["$","path","1yyitq",{"d":"M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"}],["$","path","16gr8j",{"d":"M16 3.128a4 4 0 0 1 0 7.744"}],["$","path","kshegd",{"d":"M22 21v-2a4 4 0 0 0-3-3.87"}],["$","circle","nufk8",{"cx":"9","cy":"7","r":"4"}],"$undefined"]}]}],["$","div",null,{"children":["$","h3",null,{"className":"font-semibold text-gray-900 mb-2 text-lg","children":"VT ECE Ambassadors"}]}]]}]}],["$","div",null,{"className":"px-6 pb-6","children":["$","p",null,{"className":"leading-relaxed text-gray-700","children":"Student recruitment, outreach videos, and mentorship programs"}]}]]}]]}]]}],["$","section",null,{"children":[["$","h2",null,{"className":"text-3xl font-bold text-gray-900 mb-12 text-center","children":"Key Coursework"}],["$","div",null,{"className":"bg-gray-50 rounded-lg p-8","children":["$","div",null,{"className":"grid grid-cols-2 md:grid-cols-4 gap-4","children":[["$","div","0",{"className":"bg-white rounded-lg p-4 text-center shadow-sm hover:shadow-md transition-shadow","children":["$","span",null,{"className":"text-gray-800 font-medium","children":"Embedded Systems Design"}]}],["$","div","1",{"className":"bg-white rounded-lg p-4 text-center shadow-sm hover:shadow-md transition-shadow","children":["$","span",null,{"className":"text-gray-800 font-medium","children":"Digital Signal Processing"}]}],["$","div","2",{"className":"bg-white rounded-lg p-4 text-center shadow-sm hover:shadow-md transition-shadow","children":["$","span",null,{"className":"text-gray-800 font-medium","children":"Control Systems & Robotics"}]}],["$","div","3",{"className":"bg-white rounded-lg p-4 text-center shadow-sm hover:shadow-md transition-shadow","children":["$","span",null,{"className":"text-gray-800 font-medium","children":"Machine Learning & AI"}]}],["$","div","4",{"className":"bg-white rounded-lg p-4 text-center shadow-sm hover:shadow-md transition-shadow","children":["$","span",null,{"className":"text-gray-800 font-medium","children":"Data Structures & Algorithms"}]}],["$","div","5",{"className":"bg-white rounded-lg p-4 text-center shadow-sm hover:shadow-md transition-shadow","children":["$","span",null,{"className":"text-gray-800 font-medium","children":"Computer Architecture"}]}],["$","div","6",{"className":"bg-white rounded-lg p-4 text-center shadow-sm hover:shadow-md transition-shadow","children":["$","span",null,{"className":"text-gray-800 font-medium","children":"Software Engineering"}]}],["$","div","7",{"className":"bg-white rounded-lg p-4 text-center shadow-sm hover:shadow-md transition-shadow","children":["$","span",null,{"className":"text-gray-800 font-medium","children":"Linear Systems Theory"}]}]]}]}]]}]]}]}],null],null],null]},[null,["$","$L3",null,{"parallelRouterKey":"children","segmentPath":["children","academics","children"],"error":"$undefined","errorStyles":"$undefined","errorScripts":"$undefined","template":["$","$L4",null,{}],"templateStyles":"$undefined","templateScripts":"$undefined","notFound":"$undefined","notFoundStyles":"$undefined"}]],null]},[[[["$","link","0",{"rel":"stylesheet","href":"/_next/static/css/28d069147ec3b886.css","precedence":"next","crossOrigin":"$undefined"}]],["$","html",null,{"lang":"en","children":["$","body",null,{"className":"font-sans antialiased","children":[["$","$L5",null,{}],["$","main",null,{"className":"min-h-screen","children":["$","$L3",null,{"parallelRouterKey":"children","segmentPath":["children"],"error":"$undefined","errorStyles":"$undefined","errorScripts":"$undefined","template":["$","$L4",null,{}],"templateStyles":"$undefined","templateScripts":"$undefined","notFound":[["$","title",null,{"children":"404: This page could not be found."}],["$","div",null,{"style":{"fontFamily":"system-ui,\"Segoe UI\",Roboto,Helvetica,Arial,sans-serif,\"Apple Color Emoji\",\"Segoe UI Emoji\"","height":"100vh","textAlign":"center","display":"flex","flexDirection":"column","alignItems":"center","justifyContent":"center"},"children":["$","div",null,{"children":[["$","style",null,{"dangerouslySetInnerHTML":{"__html":"body{color:#000;background:#fff;margin:0}.next-error-h1{border-right:1px solid rgba(0,0,0,.3)}@media (prefers-color-scheme:dark){body{color:#fff;background:#000}.next-error-h1{border-right:1px solid rgba(255,255,255,.3)}}"}}],["$","h1",null,{"className":"next-error-h1","style":{"display":"inline-block","margin":"0 20px 0 0","padding":"0 23px 0 0","fontSize":24,"fontWeight":500,"verticalAlign":"top","lineHeight":"49px"},"children":"404"}],["$","div",null,{"style":{"display":"inline-block"},"children":["$","h2",null,{"style":{"fontSize":14,"fontWeight":400,"lineHeight":"49px","margin":0},"children":"This page could not be found."}]}]]}]}]],"notFoundStyles":[]}]}],["$","footer",null,{"className":"bg-gray-900 text-white","children":["$","div",null,{"className":"max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12","children":[["$","div",null,{"className":"grid grid-cols-1 md:grid-cols-3 gap-8","children":[["$","div",null,{"children":[["$","h3",null,{"className":"text-lg font-semibold mb-4","children":"Contact"}],["$","div",null,{"className":"space-y-3","children":[["$","div",null,{"className":"flex items-center space-x-3","children":[["$","svg",null,{"xmlns":"http://www.w3.org/2000/svg","width":24,"height":24,"viewBox":"0 0 24 24","fill":"none","stroke":"currentColor","strokeWidth":2,"strokeLinecap":"round","strokeLinejoin":"round","className":"lucide lucide-mail w-5 h-5 text-gray-400","aria-hidden":"true","children":[["$","path","132q7q",{"d":"m22 7-8.991 5.727a2 2 0 0 1-2.009 0L2 7"}],["$","rect","izxlao",{"x":"2","y":"4","width":"20","height":"16","rx":"2"}],"$undefined"]}],["$","a",null,{"href":"mailto:yuri.braga@carefuseai.com","className":"hover:text-carefuse-teal transition-colors","children":"yuri.braga@carefuseai.com"}]]}],["$","div",null,{"className":"flex items-center space-x-3","children":[["$","svg",null,{"xmlns":"http://www.w3.org/2000/svg","width":24,"height":24,"viewBox":"0 0 24 24","fill":"none","stroke":"currentColor","strokeWidth":2,"strokeLinecap":"round","strokeLinejoin":"round","className":"lucide lucide-phone w-5 h-5 text-gray-400","aria-hidden":"true","children":[["$","path","9njp5v",{"d":"M13.832 16.568a1 1 0 0 0 1.213-.303l.355-.465A2 2 0 0 1 17 15h3a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2A18 18 0 0 1 2 4a2 2 0 0 1 2-2h3a2 2 0 0 1 2 2v3a2 2 0 0 1-.8 1.6l-.468.351a1 1 0 0 0-.292 1.233 14 14 0 0 0 6.392 6.384"}],"$undefined"]}],["$","a",null,{"href":"tel:+15409984267","className":"hover:text-carefuse-teal transition-colors","children":"+1 (540) 998-4267"}]]}]]}]]}],["$","div",null,{"children":[["$","h3",null,{"className":"text-lg font-semibold mb-4","children":"Quick Links"}],["$","div",null,{"className":"space-y-2","children":[["$","$L6",null,{"href":"/about","className":"block hover:text-carefuse-teal transition-colors","children":"About"}],["$","$L6",null,{"href":"/carefuse","className":"block hover:text-carefuse-teal transition-colors","children":"CareFuse"}],["$","$L6",null,{"href":"/academics","className":"block hover:text-carefuse-teal transition-colors","children":"Academics"}],["$","$L6",null,{"href":"/contact","className":"block hover:text-carefuse-teal transition-colors","children":"Contact"}],["$","$L6",null,{"href":"/resume","className":"block hover:text-carefuse-teal transition-colors","children":"Resume"}]]}]]}],["$","div",null,{"children":[["$","h3",null,{"className":"text-lg font-semibold mb-4","children":"Connect"}],["$","div",null,{"className":"space-y-2","children":[["$","a",null,{"href":"https://www.linkedin.com/in/yuribraga1/","target":"_blank","rel":"noopener noreferrer","className":"flex items-center space-x-2 text-gray-400 hover:text-carefuse-teal transition-colors","children":[["$","svg",null,{"xmlns":"http://www.w3.org/2000/svg","width":24,"height":24,"viewBox":"0 0 24 24","fill":"none","stroke":"currentColor","strokeWidth":2,"strokeLinecap":"round","strokeLinejoin":"round","className":"lucide lucide-linkedin w-5 h-5","aria-hidden":"true","children":[["$","path","c2jq9f",{"d":"M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"}],["$","rect","mk3on5",{"width":"4","height":"12","x":"2","y":"9"}],["$","circle","bt5ra8",{"cx":"4","cy":"4","r":"2"}],"$undefined"]}],["$","span",null,{"children":"LinkedIn"}]]}],["$","a",null,{"href":"https://carefuseai.com","target":"_blank","rel":"noopener noreferrer","className":"block text-gray-400 hover:text-vt-orange transition-colors","children":"CareFuse Website"}]]}]]}]]}],["$","div",null,{"className":"border-t border-gray-800 mt-8 pt-8 text-center","children":["$","p",null,{"className":"text-gray-400 text-sm","children":["© 2024 Yuri Braga. All rights reserved. •",["$","span",null,{"className":"ml-1","children":"Built with Next.js and Tailwind CSS"}]]}]}]]}]}]]}]}]],null],null],["$L7",null]]]]
-7:[["$","meta","0",{"name":"viewport","content":"width=device-width, initial-scale=1"}],["$","meta","1",{"charSet":"utf-8"}],["$","title","2",{"children":"Yuri Braga - Computer Engineer & Healthcare AI Researcher"}],["$","meta","3",{"name":"description","content":"Computer Engineer at Virginia Tech specializing in healthcare AI, machine learning for patient safety, and explainable AI models for clinical decision support."}],["$","meta","4",{"name":"author","content":"Yuri Braga"}],["$","meta","5",{"name":"keywords","content":"machine learning, healthcare AI, explainable AI, surgical outcomes, Total Knee Arthroplasty, MCID, patient safety, Virginia Tech, computer engineering"}],["$","meta","6",{"property":"og:title","content":"Yuri Braga - Computer Engineer & Healthcare AI Researcher"}],["$","meta","7",{"property":"og:description","content":"Computer Engineer at Virginia Tech specializing in healthcare AI, machine learning for patient safety, and explainable AI models for clinical decision support."}],["$","meta","8",{"property":"og:url","content":"https://yuribraga.dev/"}],["$","meta","9",{"property":"og:site_name","content":"Yuri Braga Portfolio"}],["$","meta","10",{"property":"og:type","content":"website"}],["$","meta","11",{"name":"twitter:card","content":"summary_large_image"}],["$","meta","12",{"name":"twitter:title","content":"Yuri Braga - Computer Engineer & Healthcare AI Researcher"}],["$","meta","13",{"name":"twitter:description","content":"Computer Engineer at Virginia Tech specializing in healthcare AI and patient safety."}],["$","link","14",{"rel":"icon","href":"/favicon.ico","type":"image/x-icon","sizes":"16x16"}]]
-1:null
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <link rel="stylesheet" href="/_next/static/css/28d069147ec3b886.css" data-precedence="next" />
+    <!-- Next.js runtime scripts removed for static GitHub Pages export -->
+    <title>
+      Yuri Braga - Computer Engineer & Healthcare AI Researcher
+    </title>
+    <meta name="description" content="Computer Engineer at Virginia Tech specializing in healthcare AI, machine learning for patient safety, and explainable AI models for clinical decision support." />
+    <meta name="author" content="Yuri Braga" />
+    <meta name="keywords" content="machine learning, healthcare AI, explainable AI, surgical outcomes, Total Knee Arthroplasty, MCID, patient safety, Virginia Tech, computer engineering" />
+    <meta property="og:title" content="Yuri Braga - Computer Engineer & Healthcare AI Researcher" />
+    <meta property="og:description" content="Computer Engineer at Virginia Tech specializing in healthcare AI, machine learning for patient safety, and explainable AI models for clinical decision support." />
+    <meta property="og:url" content="https://yuribraga.dev/" />
+    <meta property="og:site_name" content="Yuri Braga Portfolio" />
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <!-- Prevent aggressive caching by local servers/browsers -->
+    <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+    <meta http-equiv="Pragma" content="no-cache" />
+    <meta http-equiv="Expires" content="0" />
+    <meta name="twitter:title" content="Yuri Braga - Computer Engineer & Healthcare AI Researcher" />
+    <meta name="twitter:description" content="Computer Engineer at Virginia Tech specializing in healthcare AI and patient safety." />
+    <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="16x16" />
+    <script>
+      // Reload once with a cache-busting query string if GitHub Pages serves a stale home page for this route
+      (function () {
+        try {
+          var path = location.pathname;
+          var isAcademics = path.indexOf('/academics') === 0 || path.indexOf('/academics/') === 0;
+          if (!isAcademics) return;
+
+          var hasHeading = document && document.body && /Academic Journey/.test(document.body.textContent || '');
+          var hasCacheBuster = /[?&]cb=/.test(location.search);
+          if (!hasHeading && !hasCacheBuster) {
+            var separator = location.href.indexOf('?') === -1 ? '?' : '&';
+            location.replace(location.href + separator + 'cb=' + Date.now());
+          }
+        } catch (e) {
+          /* ignore */
+        }
+      })();
+    </script>
+    <!-- Next.js polyfills removed for static GitHub Pages export -->
+  </head>
+  <body class="font-sans antialiased">
+    <nav class="bg-white/95 backdrop-blur-sm border-b border-gray-200 sticky top-0 z-50">
+      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div class="flex items-center justify-between h-16">
+          <div class="flex items-center">
+            <a class="flex items-center space-x-3" href="/">
+              <img alt="CareFuse" loading="lazy" width="32" height="32" decoding="async" data-nimg="1" class="w-8 h-8" style="color:transparent" src="/images/carefuse_logo.png" />
+              <span class="text-xl font-bold text-gray-900">
+                Yuri Braga
+              </span>
+            </a>
+          </div>
+          <div class="hidden md:flex items-center space-x-8">
+            <a class="text-gray-700 hover:text-carefuse-teal transition-colors duration-200 text-sm font-medium" href="/">
+              Home
+            </a>
+            <a class="text-gray-700 hover:text-carefuse-teal transition-colors duration-200 text-sm font-medium" href="/about/">
+              About
+            </a>
+            <a class="text-gray-700 hover:text-carefuse-teal transition-colors duration-200 text-sm font-medium" href="/carefuse/">
+              CareFuse
+            </a>
+            <a class="text-gray-700 hover:text-carefuse-teal transition-colors duration-200 text-sm font-medium" href="/experience/">
+              Experience
+            </a>
+            <a class="text-gray-700 hover:text-carefuse-teal transition-colors duration-200 text-sm font-medium" href="/academics/">
+              Academics
+            </a>
+            <a class="text-gray-700 hover:text-carefuse-teal transition-colors duration-200 text-sm font-medium" href="/campus-involvement/">
+              Campus
+            </a>
+            <a class="text-gray-700 hover:text-carefuse-teal transition-colors duration-200 text-sm font-medium" href="/personal/">
+              Personal
+            </a>
+            <a class="text-gray-700 hover:text-carefuse-teal transition-colors duration-200 text-sm font-medium" href="/recommendations/">
+              Recommendations
+            </a>
+            <a class="text-gray-700 hover:text-carefuse-teal transition-colors duration-200 text-sm font-medium" href="/contact/">
+              Contact
+            </a>
+            <a class="inline-flex items-center space-x-1 bg-carefuse-teal text-white px-4 py-2 rounded-md hover:bg-carefuse-teal/90 transition-colors duration-200 text-sm font-medium" href="/resume/">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-download w-4 h-4" aria-hidden="true">
+                <path d="M12 15V3">
+                </path>
+                <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4">
+                </path>
+                <path d="m7 10 5 5 5-5">
+                </path>
+              </svg>
+              <span>
+                Resume
+              </span>
+            </a>
+          </div>
+          <div class="md:hidden">
+            <button class="text-gray-700 hover:text-carefuse-teal focus:outline-none focus:text-carefuse-teal">
+              <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-menu w-6 h-6" aria-hidden="true">
+                <path d="M4 5h16">
+                </path>
+                <path d="M4 12h16">
+                </path>
+                <path d="M4 19h16">
+                </path>
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+    </nav>
+    <main class="min-h-screen">
+      <div class="py-20 bg-white">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div class="text-center mb-16">
+            <h1 class="text-4xl sm:text-5xl font-bold text-gray-900 mb-6">
+              Academic Journey
+            </h1>
+            <p class="text-xl text-gray-600 max-w-3xl mx-auto">
+              Building a strong foundation in computer engineering with focus on robotics, AI, and embedded systems
+            </p>
+          </div>
+          <section class="mb-20">
+            <div class="rounded-lg border border-gray-200 shadow-sm hover:shadow-md hover:border-gray-300 transition-all duration-200 bg-gradient-to-br from-vt-maroon to-vt-orange text-white max-w-4xl mx-auto">
+              <div class="p-6 pb-4">
+                <div class="flex flex-col lg:flex-row items-center justify-between space-y-6 lg:space-y-0">
+                  <div class="flex items-center space-x-4">
+                    <div class="w-16 h-16 bg-white/20 rounded-lg flex items-center justify-center">
+                      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-graduation-cap w-8 h-8 text-white" aria-hidden="true">
+                        <path d="M21.42 10.922a1 1 0 0 0-.019-1.838L12.83 5.18a2 2 0 0 0-1.66 0L2.6 9.08a1 1 0 0 0 0 1.832l8.57 3.908a2 2 0 0 0 1.66 0z">
+                        </path>
+                        <path d="M22 10v6">
+                        </path>
+                        <path d="M6 12.5V16a6 3 0 0 0 12 0v-3.5">
+                        </path>
+                      </svg>
+                    </div>
+                    <div>
+                      <h3 class="font-semibold mb-2 text-white text-3xl">
+                        B.S. Computer Engineering (Software Systems)
+                      </h3>
+                      <p class="text-white/90 text-xl">
+                        Virginia Tech
+                      </p>
+                    </div>
+                  </div>
+                  <div class="flex-shrink-0">
+                    <img alt="VT Bradley Department of Electrical and Computer Engineering" loading="lazy" width="280" height="180" decoding="async" data-nimg="1" class="rounded-lg bg-white p-3" style="color:transparent" src="/images/bradley_dept_logo.jpg" />
+                  </div>
+                </div>
+              </div>
+              <div class="px-6 pb-6">
+                <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
+                  <div>
+                    <h3 class="text-xl font-semibold mb-4 flex items-center">
+                      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-award w-5 h-5 mr-2" aria-hidden="true">
+                        <path d="m15.477 12.89 1.515 8.526a.5.5 0 0 1-.81.47l-3.58-2.687a1 1 0 0 0-1.197 0l-3.586 2.686a.5.5 0 0 1-.81-.469l1.514-8.526">
+                        </path>
+                        <circle cx="12" cy="8" r="6">
+                        </circle>
+                      </svg>
+                      Academic Performance
+                    </h3>
+                    <div class="space-y-2">
+                      <div class="flex justify-between">
+                        <span>
+                          GPA:
+                        </span>
+                        <span class="font-bold">
+                          3.8/4.0
+                        </span>
+                      </div>
+                      <div class="text-white/90">
+                        Accelerated UG-to-MS coursework initiated; 3 years of research in robotics/autonomy.
+                      </div>
+                    </div>
+                  </div>
+                  <div>
+                    <h3 class="text-xl font-semibold mb-4 flex items-center">
+                      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-book-open w-5 h-5 mr-2" aria-hidden="true">
+                        <path d="M12 7v14">
+                        </path>
+                        <path d="M3 18a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1h5a4 4 0 0 1 4 4 4 4 0 0 1 4-4h5a1 1 0 0 1 1 1v13a1 1 0 0 1-1 1h-6a3 3 0 0 0-3 3 3 3 0 0 0-3-3z">
+                        </path>
+                      </svg>
+                      Specialization
+                    </h3>
+                    <p class="text-white/90">
+                      Software Systems track with emphasis on embedded systems, machine learning, and robotics applications. Accelerated undergraduate-to-master's coursework initiated.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </section>
+          <section class="mb-20">
+            <h2 class="text-3xl font-bold text-gray-900 mb-12 text-center">
+              Research Experience
+            </h2>
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
+              <div class="bg-white rounded-lg border border-gray-200 shadow-sm hover:border-gray-300 group hover:shadow-lg transition-all duration-200">
+                <div class="p-6 pb-4">
+                  <div class="flex items-start space-x-3">
+                    <div class="w-10 h-10 bg-blue-500 rounded-lg flex items-center justify-center flex-shrink-0 group-hover:scale-110 transition-transform">
+                      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-lightbulb w-5 h-5 text-white" aria-hidden="true">
+                        <path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5">
+                        </path>
+                        <path d="M9 18h6">
+                        </path>
+                        <path d="M10 22h4">
+                        </path>
+                      </svg>
+                    </div>
+                    <div>
+                      <h3 class="font-semibold text-gray-900 mb-2 text-lg">
+                        Terrestrial Robotics (TREC Lab)
+                      </h3>
+                      <p class="leading-relaxed text-vt-maroon font-medium">
+                        Aug 2022–May 2024
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <div class="px-6 pb-6">
+                  <p class="text-gray-700">
+                    Sensor integration, CAN messaging, encoder interfaces
+                  </p>
+                </div>
+              </div>
+              <div class="bg-white rounded-lg border border-gray-200 shadow-sm hover:border-gray-300 group hover:shadow-lg transition-all duration-200">
+                <div class="p-6 pb-4">
+                  <div class="flex items-start space-x-3">
+                    <div class="w-10 h-10 bg-teal-500 rounded-lg flex items-center justify-center flex-shrink-0 group-hover:scale-110 transition-transform">
+                      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-lightbulb w-5 h-5 text-white" aria-hidden="true">
+                        <path d="M15 14c.2-1 .7-1.7 1.5-2.5 1-.9 1.5-2.2 1.5-3.5A6 6 0 0 0 6 8c0 1 .2 2.2 1.5 3.5.7.7 1.3 1.5 1.5 2.5">
+                        </path>
+                        <path d="M9 18h6">
+                        </path>
+                        <path d="M10 22h4">
+                        </path>
+                      </svg>
+                    </div>
+                    <div>
+                      <h3 class="font-semibold text-gray-900 mb-2 text-lg">
+                        Marine Autonomy (CMAR)
+                      </h3>
+                      <p class="leading-relaxed text-vt-maroon font-medium">
+                        Aug 2024 - May 2025
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <div class="px-6 pb-6">
+                  <p class="text-gray-700">
+                    Bayesian obstacle detection, sonar systems, ROS integration
+                  </p>
+                </div>
+              </div>
+            </div>
+          </section>
+          <section class="mb-20">
+            <h2 class="text-3xl font-bold text-gray-900 mb-12 text-center">
+              Academic Leadership
+            </h2>
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
+              <div class="bg-white rounded-lg border border-gray-200 shadow-sm hover:border-gray-300 group hover:shadow-lg transition-all duration-200">
+                <div class="p-6 pb-4">
+                  <div class="flex items-start space-x-3">
+                    <div class="w-10 h-10 bg-green-500 rounded-lg flex items-center justify-center flex-shrink-0 group-hover:scale-110 transition-transform">
+                      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-users w-5 h-5 text-white" aria-hidden="true">
+                        <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2">
+                        </path>
+                        <path d="M16 3.128a4 4 0 0 1 0 7.744">
+                        </path>
+                        <path d="M22 21v-2a4 4 0 0 0-3-3.87">
+                        </path>
+                        <circle cx="9" cy="7" r="4">
+                        </circle>
+                      </svg>
+                    </div>
+                    <div>
+                      <h3 class="font-semibold text-gray-900 mb-2 text-lg">
+                        ECE 2564 Undergraduate Teaching Assistant
+                      </h3>
+                      <p class="leading-relaxed text-vt-maroon font-medium">
+                        July 2024 - Dec 2024
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <div class="px-6 pb-6">
+                  <p class="leading-relaxed text-gray-700">
+                    Assisted students with embedded systems programming and hardware design
+                  </p>
+                </div>
+              </div>
+              <div class="bg-white rounded-lg border border-gray-200 shadow-sm hover:border-gray-300 group hover:shadow-lg transition-all duration-200">
+                <div class="p-6 pb-4">
+                  <div class="flex items-start space-x-3">
+                    <div class="w-10 h-10 bg-purple-500 rounded-lg flex items-center justify-center flex-shrink-0 group-hover:scale-110 transition-transform">
+                      <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-users w-5 h-5 text-white" aria-hidden="true">
+                        <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2">
+                        </path>
+                        <path d="M16 3.128a4 4 0 0 1 0 7.744">
+                        </path>
+                        <path d="M22 21v-2a4 4 0 0 0-3-3.87">
+                        </path>
+                        <circle cx="9" cy="7" r="4">
+                        </circle>
+                      </svg>
+                    </div>
+                    <div>
+                      <h3 class="font-semibold text-gray-900 mb-2 text-lg">
+                        VT ECE Ambassadors — President
+                      </h3>
+                      <p class="leading-relaxed text-vt-maroon font-medium">
+                        March 2024 - Present
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <div class="px-6 pb-6">
+                  <p class="leading-relaxed text-gray-700">
+                    Student recruitment, outreach videos, and mentorship programs
+                  </p>
+                </div>
+              </div>
+            </div>
+          </section>
+          <section>
+            <h2 class="text-3xl font-bold text-gray-900 mb-12 text-center">
+              Key Coursework
+            </h2>
+            <div class="bg-gray-50 rounded-lg p-8">
+              <div class="grid grid-cols-2 md:grid-cols-4 gap-4">
+                <div class="bg-white rounded-lg p-4 text-center shadow-sm hover:shadow-md transition-shadow">
+                  <span class="text-gray-800 font-medium">Artificial Intelligence Engineering</span>
+                </div>
+                <div class="bg-white rounded-lg p-4 text-center shadow-sm hover:shadow-md transition-shadow">
+                  <span class="text-gray-800 font-medium">Computer Systems</span>
+                </div>
+                <div class="bg-white rounded-lg p-4 text-center shadow-sm hover:shadow-md transition-shadow">
+                  <span class="text-gray-800 font-medium">Advanced Real-Time Systems</span>
+                </div>
+                <div class="bg-white rounded-lg p-4 text-center shadow-sm hover:shadow-md transition-shadow">
+                  <span class="text-gray-800 font-medium">Large Scale Software Design</span>
+                </div>
+              </div>
+            </div>
+          </section>
+        </div>
+      </div>
+    </main>
+    <footer class="bg-gray-900 text-white">
+      <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
+          <div>
+            <h3 class="text-lg font-semibold mb-4">
+              Contact
+            </h3>
+            <div class="space-y-3">
+              <div class="flex items-center space-x-3">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-mail w-5 h-5 text-gray-400" aria-hidden="true">
+                  <path d="m22 7-8.991 5.727a2 2 0 0 1-2.009 0L2 7">
+                  </path>
+                  <rect x="2" y="4" width="20" height="16" rx="2">
+                  </rect>
+                </svg>
+                <a href="mailto:yuri.braga@carefuseai.com" class="hover:text-carefuse-teal transition-colors">
+                  yuri.braga@carefuseai.com
+                </a>
+              </div>
+              <div class="flex items-center space-x-3">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-phone w-5 h-5 text-gray-400" aria-hidden="true">
+                  <path d="M13.832 16.568a1 1 0 0 0 1.213-.303l.355-.465A2 2 0 0 1 17 15h3a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2A18 18 0 0 1 2 4a2 2 0 0 1 2-2h3a2 2 0 0 1 2 2v3a2 2 0 0 1-.8 1.6l-.468.351a1 1 0 0 0-.292 1.233 14 14 0 0 0 6.392 6.384">
+                  </path>
+                </svg>
+                <a href="tel:+15409984267" class="hover:text-carefuse-teal transition-colors">
+                  +1 (540) 998-4267
+                </a>
+              </div>
+            </div>
+          </div>
+          <div>
+            <h3 class="text-lg font-semibold mb-4">
+              Quick Links
+            </h3>
+            <div class="space-y-2">
+              <a class="block hover:text-carefuse-teal transition-colors" href="/about/">
+                About
+              </a>
+              <a class="block hover:text-carefuse-teal transition-colors" href="/carefuse/">
+                CareFuse
+              </a>
+              <a class="block hover:text-carefuse-teal transition-colors" href="/academics/">
+                Academics
+              </a>
+              <a class="block hover:text-carefuse-teal transition-colors" href="/contact/">
+                Contact
+              </a>
+              <a class="block hover:text-carefuse-teal transition-colors" href="/resume/">
+                Resume
+              </a>
+            </div>
+          </div>
+          <div>
+            <h3 class="text-lg font-semibold mb-4">
+              Connect
+            </h3>
+            <div class="space-y-2">
+              <a href="https://www.linkedin.com/in/yuribraga1/" target="_blank" rel="noopener noreferrer" class="flex items-center space-x-2 text-gray-400 hover:text-carefuse-teal transition-colors">
+                <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewbox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-linkedin w-5 h-5" aria-hidden="true">
+                  <path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z">
+                  </path>
+                  <rect width="4" height="12" x="2" y="9">
+                  </rect>
+                  <circle cx="4" cy="4" r="2">
+                  </circle>
+                </svg>
+                <span>
+                  LinkedIn
+                </span>
+              </a>
+              <a href="https://carefuseai.com" target="_blank" rel="noopener noreferrer" class="block text-gray-400 hover:text-vt-orange transition-colors">
+                CareFuse Website
+              </a>
+            </div>
+          </div>
+        </div>
+        <div class="border-t border-gray-800 mt-8 pt-8 text-center">
+          <p class="text-gray-400 text-sm">
+            © 2024 Yuri Braga. All rights reserved. •
+            <span class="ml-1">
+              Built with Next.js and Tailwind CSS
+            </span>
+          </p>
+        </div>
+      </div>
+    </footer>
+    <!-- Client runtime removed: this static HTML is intended to be served as-is on GitHub Pages. If you need Next.js client navigation/hydration, restore the original Next.js bootstrap and __NEXT_DATA__ payload. -->
+  </body>
+</html>

--- a/campus-involvement/index.html
+++ b/campus-involvement/index.html
@@ -17,7 +17,6 @@
 <meta name="twitter:title" content="Yuri Braga - Computer Engineer &amp; Healthcare AI Researcher"/>
 <meta name="twitter:description" content="Computer Engineer at Virginia Tech specializing in healthcare AI and patient safety."/>
 <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="16x16"/>
-<!-- Next.js client scripts removed for static GitHub Pages export -->
 </head>
 <body class="font-sans antialiased">
 <nav class="bg-white/95 backdrop-blur-sm border-b border-gray-200 sticky top-0 z-50">
@@ -28,8 +27,350 @@
 <span class="text-xl font-bold text-gray-900">Yuri Braga</span>
 </a>
 </div>
+<div class="hidden md:flex items-center space-x-8">
+<a class="text-gray-700 hover:text-carefuse-teal transition-colors duration-200 text-sm font-medium" href="/">Home</a>
+<a class="text-gray-700 hover:text-carefuse-teal transition-colors duration-200 text-sm font-medium" href="/about/">About</a>
+<a class="text-gray-700 hover:text-carefuse-teal transition-colors duration-200 text-sm font-medium" href="/carefuse/">CareFuse</a>
+<a class="text-gray-700 hover:text-carefuse-teal transition-colors duration-200 text-sm font-medium" href="/experience/">Experience</a>
+<a class="text-gray-700 hover:text-carefuse-teal transition-colors duration-200 text-sm font-medium" href="/academics/">Academics</a>
+<a class="text-gray-700 hover:text-carefuse-teal transition-colors duration-200 text-sm font-medium" href="/campus-involvement/">Campus</a>
+<a class="text-gray-700 hover:text-carefuse-teal transition-colors duration-200 text-sm font-medium" href="/personal/">Personal</a>
+<a class="text-gray-700 hover:text-carefuse-teal transition-colors duration-200 text-sm font-medium" href="/recommendations/">Recommendations</a>
+<a class="text-gray-700 hover:text-carefuse-teal transition-colors duration-200 text-sm font-medium" href="/contact/">Contact</a>
+<a class="inline-flex items-center space-x-1 bg-carefuse-teal text-white px-4 py-2 rounded-md hover:bg-carefuse-teal/90 transition-colors duration-200 text-sm font-medium" href="/resume/">
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-download w-4 h-4" aria-hidden="true">
+<path d="M12 15V3">
+</path>
+<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4">
+</path>
+<path d="m7 10 5 5 5-5">
+</path>
+</svg>
+<span>Resume</span>
+</a>
+</div>
+<div class="md:hidden">
+<button class="text-gray-700 hover:text-carefuse-teal focus:outline-none focus:text-carefuse-teal">
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-menu w-6 h-6" aria-hidden="true">
+<path d="M4 5h16">
+</path>
+<path d="M4 12h16">
+</path>
+<path d="M4 19h16">
+</path>
+</svg>
+</button>
+</div>
+</div>
+</div>
+</nav>
+<main class="min-h-screen">
+<div class="py-20 bg-white">
+<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+<div class="text-center mb-16">
+<h1 class="text-4xl sm:text-5xl font-bold text-gray-900 mb-6">Campus Involvement</h1>
+<p class="text-xl text-gray-600 max-w-3xl mx-auto">Building community, developing leadership, and making a positive impact through active participation in student organizations and campus life</p>
+</div>
+<section class="mb-20">
+<div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
+<div class="bg-white rounded-lg border border-gray-200 shadow-sm hover:border-gray-300 group hover:shadow-lg transition-all duration-200">
+<div class="p-6 pb-4">
+<div class="flex items-start space-x-4">
+<div class="w-12 h-12 bg-vt-maroon rounded-lg flex items-center justify-center flex-shrink-0 group-hover:scale-110 transition-transform">
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-video w-6 h-6 text-white" aria-hidden="true">
+<path d="m16 13 5.223 3.482a.5.5 0 0 0 .777-.416V7.87a.5.5 0 0 0-.752-.432L16 10.5">
+</path>
+<rect x="2" y="6" width="14" height="12" rx="2">
+</rect>
+</svg>
+</div>
+<div class="flex-1">
+	<h3 class="font-semibold text-gray-900 text-xl mb-1">VT ECE Ambassadors</h3>
+	<p class="leading-relaxed text-vt-maroon font-medium mb-3">President</p>
+<p class="text-gray-700 leading-relaxed mb-4">Outreach, recruitment, and advice videos.. Community building and mentorship.</p>
+</div>
+</div>
+</div>
+<div class="px-6 pb-6">
+<div class="space-y-2 mb-4">
+<div class="flex items-start">
+<span class="text-vt-maroon mr-2 mt-2 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0">
+</span>
+<span class="text-gray-600 text-sm">Featured in student recruitment videos</span>
+</div>
+<div class="flex items-start">
+<span class="text-vt-maroon mr-2 mt-2 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0">
+</span>
+<span class="text-gray-600 text-sm">Provided advice and mentorship to prospective students</span>
+</div>
+<div class="flex items-start">
+<span class="text-vt-maroon mr-2 mt-2 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0">
+</span>
+<span class="text-gray-600 text-sm">Active participant in outreach programs</span>
+</div>
+<div class="flex items-start">
+<span class="text-vt-maroon mr-2 mt-2 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0">
+</span>
+<span class="text-gray-600 text-sm">Core organization member</span>
+</div>
+</div>
+<div class="pt-4 border-t border-gray-200">
+<p class="text-sm text-gray-500 mb-2">References:</p>
+<a target="_blank" rel="noopener noreferrer" class="inline-flex items-center text-vt-maroon hover:text-vt-maroon/80 text-sm font-medium" href="https://ece.vt.edu/undergrad/ambassadors.html">ECE Ambassadors Page<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-external-link w-3 h-3 ml-1" aria-hidden="true">
+<path d="M15 3h6v6">
+</path>
+<path d="M10 14 21 3">
+</path>
+<path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6">
+</path>
+</svg>
+</a>
+</div>
+</div>
+</div>
+<div class="bg-white rounded-lg border border-gray-200 shadow-sm hover:border-gray-300 group hover:shadow-lg transition-all duration-200">
+<div class="p-6 pb-4">
+<div class="flex items-start space-x-4">
+<div class="w-12 h-12 bg-blue-500 rounded-lg flex items-center justify-center flex-shrink-0 group-hover:scale-110 transition-transform">
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-heart w-6 h-6 text-white" aria-hidden="true">
+<path d="M2 9.5a5.5 5.5 0 0 1 9.591-3.676.56.56 0 0 0 .818 0A5.49 5.49 0 0 1 22 9.5c0 2.29-1.5 4-3 5.5l-5.492 5.313a2 2 0 0 1-3 .019L5 15c-1.5-1.5-3-3.2-3-5.5">
+</path>
+</svg>
+</div>
+<div class="flex-1">
+<h3 class="font-semibold text-gray-900 text-xl mb-1">Cru at Virginia Tech</h3>
+<p class="leading-relaxed text-vt-maroon font-medium mb-3">Community Group Leader</p>
+<p class="text-gray-700 leading-relaxed mb-4">Cru at VT — Christian community for faith, service, and mentorship.</p>
+</div>
+</div>
+</div>
+<div class="px-6 pb-6">
+<div class="space-y-2 mb-4">
+<div class="flex items-start">
+<span class="text-vt-maroon mr-2 mt-2 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0">
+</span>
+<span class="text-gray-600 text-sm">Christian community focused on faith and service</span>
+</div>
+<div class="flex items-start">
+<span class="text-vt-maroon mr-2 mt-2 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0">
+</span>
+<span class="text-gray-600 text-sm">Leadership development and mentorship</span>
+</div>
+<div class="flex items-start">
+<span class="text-vt-maroon mr-2 mt-2 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0">
+</span>
+<span class="text-gray-600 text-sm">Community outreach and service projects</span>
+</div>
+<div class="flex items-start">
+<span class="text-vt-maroon mr-2 mt-2 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0">
+</span>
+<span class="text-gray-600 text-sm">Weekly fellowship and study groups</span>
+</div>
+</div>
+</div>
+</div>
+<div class="bg-white rounded-lg border border-gray-200 shadow-sm hover:border-gray-300 group hover:shadow-lg transition-all duration-200">
+<div class="p-6 pb-4">
+<div class="flex items-start space-x-4">
+<div class="w-12 h-12 bg-green-500 rounded-lg flex items-center justify-center flex-shrink-0 group-hover:scale-110 transition-transform">
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-users w-6 h-6 text-white" aria-hidden="true">
+<path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2">
+</path>
+<path d="M16 3.128a4 4 0 0 1 0 7.744">
+</path>
+<path d="M22 21v-2a4 4 0 0 0-3-3.87">
+</path>
+<circle cx="9" cy="7" r="4">
+</circle>
+</svg>
+</div>
+<div class="flex-1">
+<h3 class="font-semibold text-gray-900 text-xl mb-1">BYX (Beta Upsilon Chi)</h3>
+<p class="leading-relaxed text-vt-maroon font-medium mb-3">Brother</p>
+<p class="text-gray-700 leading-relaxed mb-4">BYX — Beta Upsilon Chi, a Christian brotherhood focused on character and service.</p>
+</div>
+</div>
+</div>
+<div class="px-6 pb-6">
+<div class="space-y-2 mb-4">
+<div class="flex items-start">
+<span class="text-vt-maroon mr-2 mt-2 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0">
+</span>
+<span class="text-gray-600 text-sm">Faith-based fraternity emphasizing character</span>
+</div>
+<div class="flex items-start">
+<span class="text-vt-maroon mr-2 mt-2 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0">
+</span>
+<span class="text-gray-600 text-sm">Brotherhood and community service</span>
+</div>
+<div class="flex items-start">
+<span class="text-vt-maroon mr-2 mt-2 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0">
+</span>
+<span class="text-gray-600 text-sm">Leadership development opportunities</span>
+</div>
+<div class="flex items-start">
+<span class="text-vt-maroon mr-2 mt-2 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0">
+</span>
+<span class="text-gray-600 text-sm">Campus and community engagement</span>
+</div>
+</div>
+</div>
+</div>
+<div class="bg-white rounded-lg border border-gray-200 shadow-sm hover:border-gray-300 group hover:shadow-lg transition-all duration-200">
+<div class="p-6 pb-4">
+<div class="flex items-start space-x-4">
+<div class="w-12 h-12 bg-orange-500 rounded-lg flex items-center justify-center flex-shrink-0 group-hover:scale-110 transition-transform">
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-trophy w-6 h-6 text-white" aria-hidden="true">
+<path d="M10 14.66v1.626a2 2 0 0 1-.976 1.696A5 5 0 0 0 7 21.978">
+</path>
+<path d="M14 14.66v1.626a2 2 0 0 0 .976 1.696A5 5 0 0 1 17 21.978">
+</path>
+<path d="M18 9h1.5a1 1 0 0 0 0-5H18">
+</path>
+<path d="M4 22h16">
+</path>
+<path d="M6 9a6 6 0 0 0 12 0V3a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1z">
+</path>
+<path d="M6 9H4.5a1 1 0 0 1 0-5H6">
+</path>
+</svg>
+</div>
+<div class="flex-1">
+	<h3 class="font-semibold text-gray-900 text-xl mb-1">Club Soccer</h3>
+	<p class="leading-relaxed text-vt-maroon font-medium mb-3">Player</p>
+	<p class="text-gray-700 leading-relaxed mb-4">Second in the nation (best in VT club soccer history) in my first semester playing with the team — I played every minute of every game. Club/IM soccer participation; teamwork, resilience; NIRSA/IMLeagues entries.</p>
+</div>
+</div>
+</div>
+<div class="px-6 pb-6">
+<div class="space-y-2 mb-4">
+<div class="flex items-start">
+<span class="text-vt-maroon mr-2 mt-2 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0">
+</span>
+<span class="text-gray-600 text-sm">Active participation in IMLeagues competitions</span>
+</div>
+<div class="flex items-start">
+<span class="text-vt-maroon mr-2 mt-2 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0">
+</span>
+<span class="text-gray-600 text-sm">Team tournaments and travel</span>
+</div>
+<div class="flex items-start">
+<span class="text-vt-maroon mr-2 mt-2 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0">
+</span>
+<span class="text-gray-600 text-sm">Lessons in resilience and teamwork</span>
+</div>
+<div class="flex items-start">
+<span class="text-vt-maroon mr-2 mt-2 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0">
+</span>
+<span class="text-gray-600 text-sm">Strategic thinking and collaboration</span>
+</div>
+</div>
+</div>
+</div>
+</div>
+</section>
+<section class="mb-20">
+<div class="rounded-lg border border-gray-200 shadow-sm hover:shadow-md hover:border-gray-300 transition-all duration-200 bg-gradient-to-br from-vt-maroon to-vt-orange text-white max-w-4xl mx-auto">
+<div class="p-8 text-center">
+<h2 class="text-2xl font-bold mb-4">Leadership Philosophy</h2>
+<p class="text-lg leading-relaxed">Through diverse campus involvement, I&#x27;ve learned that true leadership comes from serving others and building communities where everyone can thrive. Whether mentoring prospective students, participating in faith-based organizations, or competing in athletics, each experience has shaped my commitment to making a positive impact in everything I do.</p>
+</div>
+</div>
+</section>
+<section>
+<h2 class="text-2xl font-bold text-gray-900 mb-8 text-center">Featured Content</h2>
+<div class="bg-gray-50 rounded-lg p-8 text-center">
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-video w-12 h-12 text-vt-maroon mx-auto mb-4" aria-hidden="true">
+<path d="m16 13 5.223 3.482a.5.5 0 0 0 .777-.416V7.87a.5.5 0 0 0-.752-.432L16 10.5">
+</path>
+<rect x="2" y="6" width="14" height="12" rx="2">
+</rect>
+</svg>
+<h3 class="text-lg font-semibold text-gray-900 mb-2">VT ECE Ambassador Videos</h3>
+<p class="text-gray-600 mb-4">Featured in multiple Virginia Tech ECE recruitment and advice videos, sharing experiences and guidance with prospective students.</p>
+<div class="flex flex-col sm:flex-row gap-4 justify-center">
+<a target="_blank" rel="noopener noreferrer" class="inline-flex items-center text-vt-maroon hover:text-vt-maroon/80 font-medium" href="https://www.youtube.com/watch?v=example1">Student Spotlight Video<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-external-link w-4 h-4 ml-1" aria-hidden="true">
+<path d="M15 3h6v6">
+</path>
+<path d="M10 14 21 3">
+</path>
+<path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6">
+</path>
+</svg>
+</a>
+<a target="_blank" rel="noopener noreferrer" class="inline-flex items-center text-vt-maroon hover:text-vt-maroon/80 font-medium" href="https://www.youtube.com/watch?v=example2">Advice for Incoming Students<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-external-link w-4 h-4 ml-1" aria-hidden="true">
+<path d="M15 3h6v6">
+</path>
+<path d="M10 14 21 3">
+</path>
+<path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6">
+</path>
+</svg>
+</a>
+</div>
+</div>
+</section>
+</div>
+</div>
+</main>
+<footer class="bg-gray-900 text-white">
+<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+<div class="grid grid-cols-1 md:grid-cols-3 gap-8">
+<div>
+<h3 class="text-lg font-semibold mb-4">Contact</h3>
+<div class="space-y-3">
+<div class="flex items-center space-x-3">
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-mail w-5 h-5 text-gray-400" aria-hidden="true">
+<path d="m22 7-8.991 5.727a2 2 0 0 1-2.009 0L2 7">
+</path>
+<rect x="2" y="4" width="20" height="16" rx="2">
+</rect>
+</svg>
+<a href="mailto:yuri.braga@carefuseai.com" class="hover:text-carefuse-teal transition-colors">yuri.braga@carefuseai.com</a>
+</div>
+<div class="flex items-center space-x-3">
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-phone w-5 h-5 text-gray-400" aria-hidden="true">
+<path d="M13.832 16.568a1 1 0 0 0 1.213-.303l.355-.465A2 2 0 0 1 17 15h3a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2A18 18 0 0 1 2 4a2 2 0 0 1 2-2h3a2 2 0 0 1 2 2v3a2 2 0 0 1-.8 1.6l-.468.351a1 1 0 0 0-.292 1.233 14 14 0 0 0 6.392 6.384">
+</path>
+</svg>
+<a href="tel:+15409984267" class="hover:text-carefuse-teal transition-colors">+1 (540) 998-4267</a>
+</div>
+</div>
+</div>
+<div>
+<h3 class="text-lg font-semibold mb-4">Quick Links</h3>
+<div class="space-y-2">
+<a class="block hover:text-carefuse-teal transition-colors" href="/about/">About</a>
+<a class="block hover:text-carefuse-teal transition-colors" href="/carefuse/">CareFuse</a>
+<a class="block hover:text-carefuse-teal transition-colors" href="/academics/">Academics</a>
+<a class="block hover:text-carefuse-teal transition-colors" href="/contact/">Contact</a>
+<a class="block hover:text-carefuse-teal transition-colors" href="/resume/">Resume</a>
+</div>
+</div>
+<div>
+<h3 class="text-lg font-semibold mb-4">Connect</h3>
+<div class="space-y-2">
+<a href="https://www.linkedin.com/in/yuribraga1/" target="_blank" rel="noopener noreferrer" class="flex items-center space-x-2 text-gray-400 hover:text-carefuse-teal transition-colors">
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-linkedin w-5 h-5" aria-hidden="true">
+<path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z">
+</path>
+<rect width="4" height="12" x="2" y="9">
+</rect>
+<circle cx="4" cy="4" r="2">
+</circle>
+</svg>
+<span>LinkedIn</span>
+</a>
+<a href="https://carefuseai.com" target="_blank" rel="noopener noreferrer" class="block text-gray-400 hover:text-vt-orange transition-colors">CareFuse Website</a>
+</div>
+</div>
+</div>
+<div class="border-t border-gray-800 mt-8 pt-8 text-center">
+<p class="text-gray-400 text-sm">© 2024 Yuri Braga. All rights reserved. •<span class="ml-1">Built with Next.js and Tailwind CSS</span>
+</p>
+</div>
+</div>
 </footer>
-<!-- Next.js client runtime removed for static GitHub Pages export. Client-side bootstrapping scripts omitted. -->
 </body>
 </html>
 

--- a/campus-involvement/index.txt
+++ b/campus-involvement/index.txt
@@ -1,7 +1,376 @@
-2:I[2972,["972","static/chunks/972-e6acae3a74adc8b1.js","502","static/chunks/app/campus-involvement/page-88c6d01c2f63293f.js"],""]
-3:I[4707,[],""]
-4:I[6423,[],""]
-5:I[3064,["972","static/chunks/972-e6acae3a74adc8b1.js","878","static/chunks/878-a2053ba011a8f515.js","185","static/chunks/app/layout-96060b751e953699.js"],"default"]
-0:["TvnfXHU6nbvB6OIZi7NfN",[[["",{"children":["campus-involvement",{"children":["__PAGE__",{}]}]},"$undefined","$undefined",true],["",{"children":["campus-involvement",{"children":["__PAGE__",{},[["$L1",["$","div",null,{"className":"py-20 bg-white","children":["$","div",null,{"className":"max-w-7xl mx-auto px-4 sm:px-6 lg:px-8","children":[["$","div",null,{"className":"text-center mb-16","children":[["$","h1",null,{"className":"text-4xl sm:text-5xl font-bold text-gray-900 mb-6","children":"Campus Involvement"}],["$","p",null,{"className":"text-xl text-gray-600 max-w-3xl mx-auto","children":"Building community, developing leadership, and making a positive impact through active participation in student organizations and campus life"}]]}],["$","section",null,{"className":"mb-20","children":["$","div",null,{"className":"grid grid-cols-1 lg:grid-cols-2 gap-8","children":[["$","div",null,{"className":"bg-white rounded-lg border border-gray-200 shadow-sm hover:border-gray-300 group hover:shadow-lg transition-all duration-200","children":[["$","div",null,{"className":"p-6 pb-4","children":["$","div",null,{"className":"flex items-start space-x-4","children":[["$","div",null,{"className":"w-12 h-12 bg-vt-maroon rounded-lg flex items-center justify-center flex-shrink-0 group-hover:scale-110 transition-transform","children":["$","svg",null,{"xmlns":"http://www.w3.org/2000/svg","width":24,"height":24,"viewBox":"0 0 24 24","fill":"none","stroke":"currentColor","strokeWidth":2,"strokeLinecap":"round","strokeLinejoin":"round","className":"lucide lucide-video w-6 h-6 text-white","aria-hidden":"true","children":[["$","path","ftymec",{"d":"m16 13 5.223 3.482a.5.5 0 0 0 .777-.416V7.87a.5.5 0 0 0-.752-.432L16 10.5"}],["$","rect","158x01",{"x":"2","y":"6","width":"14","height":"12","rx":"2"}],"$undefined"]}]}],["$","div",null,{"className":"flex-1","children":[["$","h3",null,{"className":"font-semibold text-gray-900 text-xl mb-1","children":"VT ECE Ambassadors"}],["$","p",null,{"className":"leading-relaxed text-vt-maroon font-medium mb-3","children":"President"}],["$","p",null,{"className":"text-gray-700 leading-relaxed mb-4","children":"Outreach, recruitment, and advice videos.. Community building and mentorship."}]]}]]}]}],["$","div",null,{"className":"px-6 pb-6","children":[["$","div",null,{"className":"space-y-2 mb-4","children":[["$","div","0",{"className":"flex items-start","children":[["$","span",null,{"className":"text-vt-maroon mr-2 mt-2 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0"}],["$","span",null,{"className":"text-gray-600 text-sm","children":"Featured in student recruitment videos"}]]}],["$","div","1",{"className":"flex items-start","children":[["$","span",null,{"className":"text-vt-maroon mr-2 mt-2 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0"}],["$","span",null,{"className":"text-gray-600 text-sm","children":"Provided advice and mentorship to prospective students"}]]}],["$","div","2",{"className":"flex items-start","children":[["$","span",null,{"className":"text-vt-maroon mr-2 mt-2 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0"}],["$","span",null,{"className":"text-gray-600 text-sm","children":"Active participant in outreach programs"}]]}],["$","div","3",{"className":"flex items-start","children":[["$","span",null,{"className":"text-vt-maroon mr-2 mt-2 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0"}],["$","span",null,{"className":"text-gray-600 text-sm","children":"Core organization member"}]]}]]}],["$","div",null,{"className":"pt-4 border-t border-gray-200","children":[["$","p",null,{"className":"text-sm text-gray-500 mb-2","children":"References:"}],[["$","$L2","0",{"href":"https://ece.vt.edu/undergrad/ambassadors.html","target":"_blank","rel":"noopener noreferrer","className":"inline-flex items-center text-vt-maroon hover:text-vt-maroon/80 text-sm font-medium","children":["ECE Ambassadors Page",["$","svg",null,{"xmlns":"http://www.w3.org/2000/svg","width":24,"height":24,"viewBox":"0 0 24 24","fill":"none","stroke":"currentColor","strokeWidth":2,"strokeLinecap":"round","strokeLinejoin":"round","className":"lucide lucide-external-link w-3 h-3 ml-1","aria-hidden":"true","children":[["$","path","1q9fwt",{"d":"M15 3h6v6"}],["$","path","gplh6r",{"d":"M10 14 21 3"}],["$","path","a6xqqp",{"d":"M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"}],"$undefined"]}]]}]]]}]]}]]}],["$","div",null,{"className":"bg-white rounded-lg border border-gray-200 shadow-sm hover:border-gray-300 group hover:shadow-lg transition-all duration-200","children":[["$","div",null,{"className":"p-6 pb-4","children":["$","div",null,{"className":"flex items-start space-x-4","children":[["$","div",null,{"className":"w-12 h-12 bg-blue-500 rounded-lg flex items-center justify-center flex-shrink-0 group-hover:scale-110 transition-transform","children":["$","svg",null,{"xmlns":"http://www.w3.org/2000/svg","width":24,"height":24,"viewBox":"0 0 24 24","fill":"none","stroke":"currentColor","strokeWidth":2,"strokeLinecap":"round","strokeLinejoin":"round","className":"lucide lucide-heart w-6 h-6 text-white","aria-hidden":"true","children":[["$","path","mvr1a0",{"d":"M2 9.5a5.5 5.5 0 0 1 9.591-3.676.56.56 0 0 0 .818 0A5.49 5.49 0 0 1 22 9.5c0 2.29-1.5 4-3 5.5l-5.492 5.313a2 2 0 0 1-3 .019L5 15c-1.5-1.5-3-3.2-3-5.5"}],"$undefined"]}]}],["$","div",null,{"className":"flex-1","children":[["$","h3",null,{"className":"font-semibold text-gray-900 text-xl mb-1","children":"Cru at Virginia Tech"}],["$","p",null,{"className":"leading-relaxed text-vt-maroon font-medium mb-3","children":"Active Member"}],["$","p",null,{"className":"text-gray-700 leading-relaxed mb-4","children":"Cru at VT — Christian community for faith, service, and mentorship."}]]}]]}]}],["$","div",null,{"className":"px-6 pb-6","children":[["$","div",null,{"className":"space-y-2 mb-4","children":[["$","div","0",{"className":"flex items-start","children":[["$","span",null,{"className":"text-vt-maroon mr-2 mt-2 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0"}],["$","span",null,{"className":"text-gray-600 text-sm","children":"Christian community focused on faith and service"}]]}],["$","div","1",{"className":"flex items-start","children":[["$","span",null,{"className":"text-vt-maroon mr-2 mt-2 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0"}],["$","span",null,{"className":"text-gray-600 text-sm","children":"Leadership development and mentorship"}]]}],["$","div","2",{"className":"flex items-start","children":[["$","span",null,{"className":"text-vt-maroon mr-2 mt-2 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0"}],["$","span",null,{"className":"text-gray-600 text-sm","children":"Community outreach and service projects"}]]}],["$","div","3",{"className":"flex items-start","children":[["$","span",null,{"className":"text-vt-maroon mr-2 mt-2 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0"}],["$","span",null,{"className":"text-gray-600 text-sm","children":"Weekly fellowship and study groups"}]]}]]}],"$undefined"]}]]}],["$","div",null,{"className":"bg-white rounded-lg border border-gray-200 shadow-sm hover:border-gray-300 group hover:shadow-lg transition-all duration-200","children":[["$","div",null,{"className":"p-6 pb-4","children":["$","div",null,{"className":"flex items-start space-x-4","children":[["$","div",null,{"className":"w-12 h-12 bg-green-500 rounded-lg flex items-center justify-center flex-shrink-0 group-hover:scale-110 transition-transform","children":["$","svg",null,{"xmlns":"http://www.w3.org/2000/svg","width":24,"height":24,"viewBox":"0 0 24 24","fill":"none","stroke":"currentColor","strokeWidth":2,"strokeLinecap":"round","strokeLinejoin":"round","className":"lucide lucide-users w-6 h-6 text-white","aria-hidden":"true","children":[["$","path","1yyitq",{"d":"M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"}],["$","path","16gr8j",{"d":"M16 3.128a4 4 0 0 1 0 7.744"}],["$","path","kshegd",{"d":"M22 21v-2a4 4 0 0 0-3-3.87"}],["$","circle","nufk8",{"cx":"9","cy":"7","r":"4"}],"$undefined"]}]}],["$","div",null,{"className":"flex-1","children":[["$","h3",null,{"className":"font-semibold text-gray-900 text-xl mb-1","children":"BYX (Beta Upsilon Chi)"}],["$","p",null,{"className":"leading-relaxed text-vt-maroon font-medium mb-3","children":"Brother"}],["$","p",null,{"className":"text-gray-700 leading-relaxed mb-4","children":"BYX — Beta Upsilon Chi, a Christian brotherhood focused on character and service."}]]}]]}]}],["$","div",null,{"className":"px-6 pb-6","children":[["$","div",null,{"className":"space-y-2 mb-4","children":[["$","div","0",{"className":"flex items-start","children":[["$","span",null,{"className":"text-vt-maroon mr-2 mt-2 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0"}],["$","span",null,{"className":"text-gray-600 text-sm","children":"Faith-based fraternity emphasizing character"}]]}],["$","div","1",{"className":"flex items-start","children":[["$","span",null,{"className":"text-vt-maroon mr-2 mt-2 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0"}],["$","span",null,{"className":"text-gray-600 text-sm","children":"Brotherhood and community service"}]]}],["$","div","2",{"className":"flex items-start","children":[["$","span",null,{"className":"text-vt-maroon mr-2 mt-2 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0"}],["$","span",null,{"className":"text-gray-600 text-sm","children":"Leadership development opportunities"}]]}],["$","div","3",{"className":"flex items-start","children":[["$","span",null,{"className":"text-vt-maroon mr-2 mt-2 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0"}],["$","span",null,{"className":"text-gray-600 text-sm","children":"Campus and community engagement"}]]}]]}],"$undefined"]}]]}],["$","div",null,{"className":"bg-white rounded-lg border border-gray-200 shadow-sm hover:border-gray-300 group hover:shadow-lg transition-all duration-200","children":[["$","div",null,{"className":"p-6 pb-4","children":["$","div",null,{"className":"flex items-start space-x-4","children":[["$","div",null,{"className":"w-12 h-12 bg-orange-500 rounded-lg flex items-center justify-center flex-shrink-0 group-hover:scale-110 transition-transform","children":["$","svg",null,{"xmlns":"http://www.w3.org/2000/svg","width":24,"height":24,"viewBox":"0 0 24 24","fill":"none","stroke":"currentColor","strokeWidth":2,"strokeLinecap":"round","strokeLinejoin":"round","className":"lucide lucide-trophy w-6 h-6 text-white","aria-hidden":"true","children":[["$","path","1n3hpd",{"d":"M10 14.66v1.626a2 2 0 0 1-.976 1.696A5 5 0 0 0 7 21.978"}],["$","path","rfe1zi",{"d":"M14 14.66v1.626a2 2 0 0 0 .976 1.696A5 5 0 0 1 17 21.978"}],["$","path","7xy6bh",{"d":"M18 9h1.5a1 1 0 0 0 0-5H18"}],["$","path","57wxv0",{"d":"M4 22h16"}],["$","path","1mhfuq",{"d":"M6 9a6 6 0 0 0 12 0V3a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1z"}],["$","path","tex48p",{"d":"M6 9H4.5a1 1 0 0 1 0-5H6"}],"$undefined"]}]}],["$","div",null,{"className":"flex-1","children":[["$","h3",null,{"className":"font-semibold text-gray-900 text-xl mb-1","children":"Club Soccer"}],["$","p",null,{"className":"leading-relaxed text-vt-maroon font-medium mb-3","children":"Team Member"}],["$","p",null,{"className":"text-gray-700 leading-relaxed mb-4","children":"Club/IM soccer participation; teamwork, resilience; NIRSA/IMLeagues entries."}]]}]]}]}],["$","div",null,{"className":"px-6 pb-6","children":[["$","div",null,{"className":"space-y-2 mb-4","children":[["$","div","0",{"className":"flex items-start","children":[["$","span",null,{"className":"text-vt-maroon mr-2 mt-2 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0"}],["$","span",null,{"className":"text-gray-600 text-sm","children":"Active participation in IMLeagues competitions"}]]}],["$","div","1",{"className":"flex items-start","children":[["$","span",null,{"className":"text-vt-maroon mr-2 mt-2 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0"}],["$","span",null,{"className":"text-gray-600 text-sm","children":"Team tournaments and travel"}]]}],["$","div","2",{"className":"flex items-start","children":[["$","span",null,{"className":"text-vt-maroon mr-2 mt-2 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0"}],["$","span",null,{"className":"text-gray-600 text-sm","children":"Lessons in resilience and teamwork"}]]}],["$","div","3",{"className":"flex items-start","children":[["$","span",null,{"className":"text-vt-maroon mr-2 mt-2 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0"}],["$","span",null,{"className":"text-gray-600 text-sm","children":"Strategic thinking and collaboration"}]]}]]}],"$undefined"]}]]}]]}]}],["$","section",null,{"className":"mb-20","children":["$","div",null,{"className":"rounded-lg border border-gray-200 shadow-sm hover:shadow-md hover:border-gray-300 transition-all duration-200 bg-gradient-to-br from-vt-maroon to-vt-orange text-white max-w-4xl mx-auto","children":["$","div",null,{"className":"p-8 text-center","children":[["$","h2",null,{"className":"text-2xl font-bold mb-4","children":"Leadership Philosophy"}],["$","p",null,{"className":"text-lg leading-relaxed","children":"Through diverse campus involvement, I've learned that true leadership comes from serving others and building communities where everyone can thrive. Whether mentoring prospective students, participating in faith-based organizations, or competing in athletics, each experience has shaped my commitment to making a positive impact in everything I do."}]]}]}]}],["$","section",null,{"children":[["$","h2",null,{"className":"text-2xl font-bold text-gray-900 mb-8 text-center","children":"Featured Content"}],["$","div",null,{"className":"bg-gray-50 rounded-lg p-8 text-center","children":[["$","svg",null,{"xmlns":"http://www.w3.org/2000/svg","width":24,"height":24,"viewBox":"0 0 24 24","fill":"none","stroke":"currentColor","strokeWidth":2,"strokeLinecap":"round","strokeLinejoin":"round","className":"lucide lucide-video w-12 h-12 text-vt-maroon mx-auto mb-4","aria-hidden":"true","children":[["$","path","ftymec",{"d":"m16 13 5.223 3.482a.5.5 0 0 0 .777-.416V7.87a.5.5 0 0 0-.752-.432L16 10.5"}],["$","rect","158x01",{"x":"2","y":"6","width":"14","height":"12","rx":"2"}],"$undefined"]}],["$","h3",null,{"className":"text-lg font-semibold text-gray-900 mb-2","children":"VT ECE Ambassador Videos"}],["$","p",null,{"className":"text-gray-600 mb-4","children":"Featured in multiple Virginia Tech ECE recruitment and advice videos, sharing experiences and guidance with prospective students."}],["$","div",null,{"className":"flex flex-col sm:flex-row gap-4 justify-center","children":[["$","$L2",null,{"href":"https://www.youtube.com/watch?v=example1","target":"_blank","rel":"noopener noreferrer","className":"inline-flex items-center text-vt-maroon hover:text-vt-maroon/80 font-medium","children":["Student Spotlight Video",["$","svg",null,{"xmlns":"http://www.w3.org/2000/svg","width":24,"height":24,"viewBox":"0 0 24 24","fill":"none","stroke":"currentColor","strokeWidth":2,"strokeLinecap":"round","strokeLinejoin":"round","className":"lucide lucide-external-link w-4 h-4 ml-1","aria-hidden":"true","children":[["$","path","1q9fwt",{"d":"M15 3h6v6"}],["$","path","gplh6r",{"d":"M10 14 21 3"}],["$","path","a6xqqp",{"d":"M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"}],"$undefined"]}]]}],["$","$L2",null,{"href":"https://www.youtube.com/watch?v=example2","target":"_blank","rel":"noopener noreferrer","className":"inline-flex items-center text-vt-maroon hover:text-vt-maroon/80 font-medium","children":["Advice for Incoming Students",["$","svg",null,{"xmlns":"http://www.w3.org/2000/svg","width":24,"height":24,"viewBox":"0 0 24 24","fill":"none","stroke":"currentColor","strokeWidth":2,"strokeLinecap":"round","strokeLinejoin":"round","className":"lucide lucide-external-link w-4 h-4 ml-1","aria-hidden":"true","children":[["$","path","1q9fwt",{"d":"M15 3h6v6"}],["$","path","gplh6r",{"d":"M10 14 21 3"}],["$","path","a6xqqp",{"d":"M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"}],"$undefined"]}]]}]]}]]}]]}]]}]}],null],null],null]},[null,["$","$L3",null,{"parallelRouterKey":"children","segmentPath":["children","campus-involvement","children"],"error":"$undefined","errorStyles":"$undefined","errorScripts":"$undefined","template":["$","$L4",null,{}],"templateStyles":"$undefined","templateScripts":"$undefined","notFound":"$undefined","notFoundStyles":"$undefined"}]],null]},[[[["$","link","0",{"rel":"stylesheet","href":"/_next/static/css/28d069147ec3b886.css","precedence":"next","crossOrigin":"$undefined"}]],["$","html",null,{"lang":"en","children":["$","body",null,{"className":"font-sans antialiased","children":[["$","$L5",null,{}],["$","main",null,{"className":"min-h-screen","children":["$","$L3",null,{"parallelRouterKey":"children","segmentPath":["children"],"error":"$undefined","errorStyles":"$undefined","errorScripts":"$undefined","template":["$","$L4",null,{}],"templateStyles":"$undefined","templateScripts":"$undefined","notFound":[["$","title",null,{"children":"404: This page could not be found."}],["$","div",null,{"style":{"fontFamily":"system-ui,\"Segoe UI\",Roboto,Helvetica,Arial,sans-serif,\"Apple Color Emoji\",\"Segoe UI Emoji\"","height":"100vh","textAlign":"center","display":"flex","flexDirection":"column","alignItems":"center","justifyContent":"center"},"children":["$","div",null,{"children":[["$","style",null,{"dangerouslySetInnerHTML":{"__html":"body{color:#000;background:#fff;margin:0}.next-error-h1{border-right:1px solid rgba(0,0,0,.3)}@media (prefers-color-scheme:dark){body{color:#fff;background:#000}.next-error-h1{border-right:1px solid rgba(255,255,255,.3)}}"}}],["$","h1",null,{"className":"next-error-h1","style":{"display":"inline-block","margin":"0 20px 0 0","padding":"0 23px 0 0","fontSize":24,"fontWeight":500,"verticalAlign":"top","lineHeight":"49px"},"children":"404"}],["$","div",null,{"style":{"display":"inline-block"},"children":["$","h2",null,{"style":{"fontSize":14,"fontWeight":400,"lineHeight":"49px","margin":0},"children":"This page could not be found."}]}]]}]}]],"notFoundStyles":[]}]}],["$","footer",null,{"className":"bg-gray-900 text-white","children":["$","div",null,{"className":"max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12","children":[["$","div",null,{"className":"grid grid-cols-1 md:grid-cols-3 gap-8","children":[["$","div",null,{"children":[["$","h3",null,{"className":"text-lg font-semibold mb-4","children":"Contact"}],["$","div",null,{"className":"space-y-3","children":[["$","div",null,{"className":"flex items-center space-x-3","children":[["$","svg",null,{"xmlns":"http://www.w3.org/2000/svg","width":24,"height":24,"viewBox":"0 0 24 24","fill":"none","stroke":"currentColor","strokeWidth":2,"strokeLinecap":"round","strokeLinejoin":"round","className":"lucide lucide-mail w-5 h-5 text-gray-400","aria-hidden":"true","children":[["$","path","132q7q",{"d":"m22 7-8.991 5.727a2 2 0 0 1-2.009 0L2 7"}],["$","rect","izxlao",{"x":"2","y":"4","width":"20","height":"16","rx":"2"}],"$undefined"]}],["$","a",null,{"href":"mailto:yuri.braga@carefuseai.com","className":"hover:text-carefuse-teal transition-colors","children":"yuri.braga@carefuseai.com"}]]}],["$","div",null,{"className":"flex items-center space-x-3","children":[["$","svg",null,{"xmlns":"http://www.w3.org/2000/svg","width":24,"height":24,"viewBox":"0 0 24 24","fill":"none","stroke":"currentColor","strokeWidth":2,"strokeLinecap":"round","strokeLinejoin":"round","className":"lucide lucide-phone w-5 h-5 text-gray-400","aria-hidden":"true","children":[["$","path","9njp5v",{"d":"M13.832 16.568a1 1 0 0 0 1.213-.303l.355-.465A2 2 0 0 1 17 15h3a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2A18 18 0 0 1 2 4a2 2 0 0 1 2-2h3a2 2 0 0 1 2 2v3a2 2 0 0 1-.8 1.6l-.468.351a1 1 0 0 0-.292 1.233 14 14 0 0 0 6.392 6.384"}],"$undefined"]}],["$","a",null,{"href":"tel:+15409984267","className":"hover:text-carefuse-teal transition-colors","children":"+1 (540) 998-4267"}]]}]]}]]}],["$","div",null,{"children":[["$","h3",null,{"className":"text-lg font-semibold mb-4","children":"Quick Links"}],["$","div",null,{"className":"space-y-2","children":[["$","$L2",null,{"href":"/about","className":"block hover:text-carefuse-teal transition-colors","children":"About"}],["$","$L2",null,{"href":"/carefuse","className":"block hover:text-carefuse-teal transition-colors","children":"CareFuse"}],["$","$L2",null,{"href":"/academics","className":"block hover:text-carefuse-teal transition-colors","children":"Academics"}],["$","$L2",null,{"href":"/contact","className":"block hover:text-carefuse-teal transition-colors","children":"Contact"}],["$","$L2",null,{"href":"/resume","className":"block hover:text-carefuse-teal transition-colors","children":"Resume"}]]}]]}],["$","div",null,{"children":[["$","h3",null,{"className":"text-lg font-semibold mb-4","children":"Connect"}],["$","div",null,{"className":"space-y-2","children":[["$","a",null,{"href":"https://www.linkedin.com/in/yuribraga1/","target":"_blank","rel":"noopener noreferrer","className":"flex items-center space-x-2 text-gray-400 hover:text-carefuse-teal transition-colors","children":[["$","svg",null,{"xmlns":"http://www.w3.org/2000/svg","width":24,"height":24,"viewBox":"0 0 24 24","fill":"none","stroke":"currentColor","strokeWidth":2,"strokeLinecap":"round","strokeLinejoin":"round","className":"lucide lucide-linkedin w-5 h-5","aria-hidden":"true","children":[["$","path","c2jq9f",{"d":"M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"}],["$","rect","mk3on5",{"width":"4","height":"12","x":"2","y":"9"}],["$","circle","bt5ra8",{"cx":"4","cy":"4","r":"2"}],"$undefined"]}],["$","span",null,{"children":"LinkedIn"}]]}],["$","a",null,{"href":"https://carefuseai.com","target":"_blank","rel":"noopener noreferrer","className":"block text-gray-400 hover:text-vt-orange transition-colors","children":"CareFuse Website"}]]}]]}]]}],["$","div",null,{"className":"border-t border-gray-800 mt-8 pt-8 text-center","children":["$","p",null,{"className":"text-gray-400 text-sm","children":["© 2024 Yuri Braga. All rights reserved. •",["$","span",null,{"className":"ml-1","children":"Built with Next.js and Tailwind CSS"}]]}]}]]}]}]]}]}]],null],null],["$L6",null]]]]
-6:[["$","meta","0",{"name":"viewport","content":"width=device-width, initial-scale=1"}],["$","meta","1",{"charSet":"utf-8"}],["$","title","2",{"children":"Yuri Braga - Computer Engineer & Healthcare AI Researcher"}],["$","meta","3",{"name":"description","content":"Computer Engineer at Virginia Tech specializing in healthcare AI, machine learning for patient safety, and explainable AI models for clinical decision support."}],["$","meta","4",{"name":"author","content":"Yuri Braga"}],["$","meta","5",{"name":"keywords","content":"machine learning, healthcare AI, explainable AI, surgical outcomes, Total Knee Arthroplasty, MCID, patient safety, Virginia Tech, computer engineering"}],["$","meta","6",{"property":"og:title","content":"Yuri Braga - Computer Engineer & Healthcare AI Researcher"}],["$","meta","7",{"property":"og:description","content":"Computer Engineer at Virginia Tech specializing in healthcare AI, machine learning for patient safety, and explainable AI models for clinical decision support."}],["$","meta","8",{"property":"og:url","content":"https://yuribraga.dev/"}],["$","meta","9",{"property":"og:site_name","content":"Yuri Braga Portfolio"}],["$","meta","10",{"property":"og:type","content":"website"}],["$","meta","11",{"name":"twitter:card","content":"summary_large_image"}],["$","meta","12",{"name":"twitter:title","content":"Yuri Braga - Computer Engineer & Healthcare AI Researcher"}],["$","meta","13",{"name":"twitter:description","content":"Computer Engineer at Virginia Tech specializing in healthcare AI and patient safety."}],["$","link","14",{"rel":"icon","href":"/favicon.ico","type":"image/x-icon","sizes":"16x16"}]]
-1:null
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charSet="utf-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<link rel="stylesheet" href="/_next/static/css/28d069147ec3b886.css" data-precedence="next"/>
+<title>Yuri Braga - Computer Engineer &amp; Healthcare AI Researcher</title>
+<meta name="description" content="Computer Engineer at Virginia Tech specializing in healthcare AI, machine learning for patient safety, and explainable AI models for clinical decision support."/>
+<meta name="author" content="Yuri Braga"/>
+<meta name="keywords" content="machine learning, healthcare AI, explainable AI, surgical outcomes, Total Knee Arthroplasty, MCID, patient safety, Virginia Tech, computer engineering"/>
+<meta property="og:title" content="Yuri Braga - Computer Engineer &amp; Healthcare AI Researcher"/>
+<meta property="og:description" content="Computer Engineer at Virginia Tech specializing in healthcare AI, machine learning for patient safety, and explainable AI models for clinical decision support."/>
+<meta property="og:url" content="https://yuribraga.dev/"/>
+<meta property="og:site_name" content="Yuri Braga Portfolio"/>
+<meta property="og:type" content="website"/>
+<meta name="twitter:card" content="summary_large_image"/>
+<meta name="twitter:title" content="Yuri Braga - Computer Engineer &amp; Healthcare AI Researcher"/>
+<meta name="twitter:description" content="Computer Engineer at Virginia Tech specializing in healthcare AI and patient safety."/>
+<link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="16x16"/>
+</head>
+<body class="font-sans antialiased">
+<nav class="bg-white/95 backdrop-blur-sm border-b border-gray-200 sticky top-0 z-50">
+<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">        <div class="flex items-center justify-between h-16">
+<div class="flex items-center">
+<a class="flex items-center space-x-3" href="/">
+<img alt="CareFuse" loading="lazy" width="32" height="32" decoding="async" data-nimg="1" class="w-8 h-8" style="color:transparent" src="/images/carefuse_logo.png"/>
+<span class="text-xl font-bold text-gray-900">Yuri Braga</span>
+</a>
+</div>
+<div class="hidden md:flex items-center space-x-8">
+<a class="text-gray-700 hover:text-carefuse-teal transition-colors duration-200 text-sm font-medium" href="/">Home</a>
+<a class="text-gray-700 hover:text-carefuse-teal transition-colors duration-200 text-sm font-medium" href="/about/">About</a>
+<a class="text-gray-700 hover:text-carefuse-teal transition-colors duration-200 text-sm font-medium" href="/carefuse/">CareFuse</a>
+<a class="text-gray-700 hover:text-carefuse-teal transition-colors duration-200 text-sm font-medium" href="/experience/">Experience</a>
+<a class="text-gray-700 hover:text-carefuse-teal transition-colors duration-200 text-sm font-medium" href="/academics/">Academics</a>
+<a class="text-gray-700 hover:text-carefuse-teal transition-colors duration-200 text-sm font-medium" href="/campus-involvement/">Campus</a>
+<a class="text-gray-700 hover:text-carefuse-teal transition-colors duration-200 text-sm font-medium" href="/personal/">Personal</a>
+<a class="text-gray-700 hover:text-carefuse-teal transition-colors duration-200 text-sm font-medium" href="/recommendations/">Recommendations</a>
+<a class="text-gray-700 hover:text-carefuse-teal transition-colors duration-200 text-sm font-medium" href="/contact/">Contact</a>
+<a class="inline-flex items-center space-x-1 bg-carefuse-teal text-white px-4 py-2 rounded-md hover:bg-carefuse-teal/90 transition-colors duration-200 text-sm font-medium" href="/resume/">
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-download w-4 h-4" aria-hidden="true">
+<path d="M12 15V3">
+</path>
+<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4">
+</path>
+<path d="m7 10 5 5 5-5">
+</path>
+</svg>
+<span>Resume</span>
+</a>
+</div>
+<div class="md:hidden">
+<button class="text-gray-700 hover:text-carefuse-teal focus:outline-none focus:text-carefuse-teal">
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-menu w-6 h-6" aria-hidden="true">
+<path d="M4 5h16">
+</path>
+<path d="M4 12h16">
+</path>
+<path d="M4 19h16">
+</path>
+</svg>
+</button>
+</div>
+</div>
+</div>
+</nav>
+<main class="min-h-screen">
+<div class="py-20 bg-white">
+<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+<div class="text-center mb-16">
+<h1 class="text-4xl sm:text-5xl font-bold text-gray-900 mb-6">Campus Involvement</h1>
+<p class="text-xl text-gray-600 max-w-3xl mx-auto">Building community, developing leadership, and making a positive impact through active participation in student organizations and campus life</p>
+</div>
+<section class="mb-20">
+<div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
+<div class="bg-white rounded-lg border border-gray-200 shadow-sm hover:border-gray-300 group hover:shadow-lg transition-all duration-200">
+<div class="p-6 pb-4">
+<div class="flex items-start space-x-4">
+<div class="w-12 h-12 bg-vt-maroon rounded-lg flex items-center justify-center flex-shrink-0 group-hover:scale-110 transition-transform">
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-video w-6 h-6 text-white" aria-hidden="true">
+<path d="m16 13 5.223 3.482a.5.5 0 0 0 .777-.416V7.87a.5.5 0 0 0-.752-.432L16 10.5">
+</path>
+<rect x="2" y="6" width="14" height="12" rx="2">
+</rect>
+</svg>
+</div>
+<div class="flex-1">
+	<h3 class="font-semibold text-gray-900 text-xl mb-1">VT ECE Ambassadors</h3>
+	<p class="leading-relaxed text-vt-maroon font-medium mb-3">President</p>
+<p class="text-gray-700 leading-relaxed mb-4">Outreach, recruitment, and advice videos.. Community building and mentorship.</p>
+</div>
+</div>
+</div>
+<div class="px-6 pb-6">
+<div class="space-y-2 mb-4">
+<div class="flex items-start">
+<span class="text-vt-maroon mr-2 mt-2 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0">
+</span>
+<span class="text-gray-600 text-sm">Featured in student recruitment videos</span>
+</div>
+<div class="flex items-start">
+<span class="text-vt-maroon mr-2 mt-2 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0">
+</span>
+<span class="text-gray-600 text-sm">Provided advice and mentorship to prospective students</span>
+</div>
+<div class="flex items-start">
+<span class="text-vt-maroon mr-2 mt-2 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0">
+</span>
+<span class="text-gray-600 text-sm">Active participant in outreach programs</span>
+</div>
+<div class="flex items-start">
+<span class="text-vt-maroon mr-2 mt-2 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0">
+</span>
+<span class="text-gray-600 text-sm">Core organization member</span>
+</div>
+</div>
+<div class="pt-4 border-t border-gray-200">
+<p class="text-sm text-gray-500 mb-2">References:</p>
+<a target="_blank" rel="noopener noreferrer" class="inline-flex items-center text-vt-maroon hover:text-vt-maroon/80 text-sm font-medium" href="https://ece.vt.edu/undergrad/ambassadors.html">ECE Ambassadors Page<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-external-link w-3 h-3 ml-1" aria-hidden="true">
+<path d="M15 3h6v6">
+</path>
+<path d="M10 14 21 3">
+</path>
+<path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6">
+</path>
+</svg>
+</a>
+</div>
+</div>
+</div>
+<div class="bg-white rounded-lg border border-gray-200 shadow-sm hover:border-gray-300 group hover:shadow-lg transition-all duration-200">
+<div class="p-6 pb-4">
+<div class="flex items-start space-x-4">
+<div class="w-12 h-12 bg-blue-500 rounded-lg flex items-center justify-center flex-shrink-0 group-hover:scale-110 transition-transform">
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-heart w-6 h-6 text-white" aria-hidden="true">
+<path d="M2 9.5a5.5 5.5 0 0 1 9.591-3.676.56.56 0 0 0 .818 0A5.49 5.49 0 0 1 22 9.5c0 2.29-1.5 4-3 5.5l-5.492 5.313a2 2 0 0 1-3 .019L5 15c-1.5-1.5-3-3.2-3-5.5">
+</path>
+</svg>
+</div>
+<div class="flex-1">
+<h3 class="font-semibold text-gray-900 text-xl mb-1">Cru at Virginia Tech</h3>
+<p class="leading-relaxed text-vt-maroon font-medium mb-3">Community Group Leader</p>
+<p class="text-gray-700 leading-relaxed mb-4">Cru at VT — Christian community for faith, service, and mentorship.</p>
+</div>
+</div>
+</div>
+<div class="px-6 pb-6">
+<div class="space-y-2 mb-4">
+<div class="flex items-start">
+<span class="text-vt-maroon mr-2 mt-2 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0">
+</span>
+<span class="text-gray-600 text-sm">Christian community focused on faith and service</span>
+</div>
+<div class="flex items-start">
+<span class="text-vt-maroon mr-2 mt-2 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0">
+</span>
+<span class="text-gray-600 text-sm">Leadership development and mentorship</span>
+</div>
+<div class="flex items-start">
+<span class="text-vt-maroon mr-2 mt-2 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0">
+</span>
+<span class="text-gray-600 text-sm">Community outreach and service projects</span>
+</div>
+<div class="flex items-start">
+<span class="text-vt-maroon mr-2 mt-2 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0">
+</span>
+<span class="text-gray-600 text-sm">Weekly fellowship and study groups</span>
+</div>
+</div>
+</div>
+</div>
+<div class="bg-white rounded-lg border border-gray-200 shadow-sm hover:border-gray-300 group hover:shadow-lg transition-all duration-200">
+<div class="p-6 pb-4">
+<div class="flex items-start space-x-4">
+<div class="w-12 h-12 bg-green-500 rounded-lg flex items-center justify-center flex-shrink-0 group-hover:scale-110 transition-transform">
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-users w-6 h-6 text-white" aria-hidden="true">
+<path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2">
+</path>
+<path d="M16 3.128a4 4 0 0 1 0 7.744">
+</path>
+<path d="M22 21v-2a4 4 0 0 0-3-3.87">
+</path>
+<circle cx="9" cy="7" r="4">
+</circle>
+</svg>
+</div>
+<div class="flex-1">
+<h3 class="font-semibold text-gray-900 text-xl mb-1">BYX (Beta Upsilon Chi)</h3>
+<p class="leading-relaxed text-vt-maroon font-medium mb-3">Brother</p>
+<p class="text-gray-700 leading-relaxed mb-4">BYX — Beta Upsilon Chi, a Christian brotherhood focused on character and service.</p>
+</div>
+</div>
+</div>
+<div class="px-6 pb-6">
+<div class="space-y-2 mb-4">
+<div class="flex items-start">
+<span class="text-vt-maroon mr-2 mt-2 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0">
+</span>
+<span class="text-gray-600 text-sm">Faith-based fraternity emphasizing character</span>
+</div>
+<div class="flex items-start">
+<span class="text-vt-maroon mr-2 mt-2 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0">
+</span>
+<span class="text-gray-600 text-sm">Brotherhood and community service</span>
+</div>
+<div class="flex items-start">
+<span class="text-vt-maroon mr-2 mt-2 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0">
+</span>
+<span class="text-gray-600 text-sm">Leadership development opportunities</span>
+</div>
+<div class="flex items-start">
+<span class="text-vt-maroon mr-2 mt-2 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0">
+</span>
+<span class="text-gray-600 text-sm">Campus and community engagement</span>
+</div>
+</div>
+</div>
+</div>
+<div class="bg-white rounded-lg border border-gray-200 shadow-sm hover:border-gray-300 group hover:shadow-lg transition-all duration-200">
+<div class="p-6 pb-4">
+<div class="flex items-start space-x-4">
+<div class="w-12 h-12 bg-orange-500 rounded-lg flex items-center justify-center flex-shrink-0 group-hover:scale-110 transition-transform">
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-trophy w-6 h-6 text-white" aria-hidden="true">
+<path d="M10 14.66v1.626a2 2 0 0 1-.976 1.696A5 5 0 0 0 7 21.978">
+</path>
+<path d="M14 14.66v1.626a2 2 0 0 0 .976 1.696A5 5 0 0 1 17 21.978">
+</path>
+<path d="M18 9h1.5a1 1 0 0 0 0-5H18">
+</path>
+<path d="M4 22h16">
+</path>
+<path d="M6 9a6 6 0 0 0 12 0V3a1 1 0 0 0-1-1H7a1 1 0 0 0-1 1z">
+</path>
+<path d="M6 9H4.5a1 1 0 0 1 0-5H6">
+</path>
+</svg>
+</div>
+<div class="flex-1">
+	<h3 class="font-semibold text-gray-900 text-xl mb-1">Club Soccer</h3>
+	<p class="leading-relaxed text-vt-maroon font-medium mb-3">Player</p>
+	<p class="text-gray-700 leading-relaxed mb-4">Second in the nation (best in VT club soccer history) in my first semester playing with the team — I played every minute of every game. Club/IM soccer participation; teamwork, resilience; NIRSA/IMLeagues entries.</p>
+</div>
+</div>
+</div>
+<div class="px-6 pb-6">
+<div class="space-y-2 mb-4">
+<div class="flex items-start">
+<span class="text-vt-maroon mr-2 mt-2 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0">
+</span>
+<span class="text-gray-600 text-sm">Active participation in IMLeagues competitions</span>
+</div>
+<div class="flex items-start">
+<span class="text-vt-maroon mr-2 mt-2 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0">
+</span>
+<span class="text-gray-600 text-sm">Team tournaments and travel</span>
+</div>
+<div class="flex items-start">
+<span class="text-vt-maroon mr-2 mt-2 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0">
+</span>
+<span class="text-gray-600 text-sm">Lessons in resilience and teamwork</span>
+</div>
+<div class="flex items-start">
+<span class="text-vt-maroon mr-2 mt-2 w-1.5 h-1.5 rounded-full bg-current flex-shrink-0">
+</span>
+<span class="text-gray-600 text-sm">Strategic thinking and collaboration</span>
+</div>
+</div>
+</div>
+</div>
+</div>
+</section>
+<section class="mb-20">
+<div class="rounded-lg border border-gray-200 shadow-sm hover:shadow-md hover:border-gray-300 transition-all duration-200 bg-gradient-to-br from-vt-maroon to-vt-orange text-white max-w-4xl mx-auto">
+<div class="p-8 text-center">
+<h2 class="text-2xl font-bold mb-4">Leadership Philosophy</h2>
+<p class="text-lg leading-relaxed">Through diverse campus involvement, I&#x27;ve learned that true leadership comes from serving others and building communities where everyone can thrive. Whether mentoring prospective students, participating in faith-based organizations, or competing in athletics, each experience has shaped my commitment to making a positive impact in everything I do.</p>
+</div>
+</div>
+</section>
+<section>
+<h2 class="text-2xl font-bold text-gray-900 mb-8 text-center">Featured Content</h2>
+<div class="bg-gray-50 rounded-lg p-8 text-center">
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-video w-12 h-12 text-vt-maroon mx-auto mb-4" aria-hidden="true">
+<path d="m16 13 5.223 3.482a.5.5 0 0 0 .777-.416V7.87a.5.5 0 0 0-.752-.432L16 10.5">
+</path>
+<rect x="2" y="6" width="14" height="12" rx="2">
+</rect>
+</svg>
+<h3 class="text-lg font-semibold text-gray-900 mb-2">VT ECE Ambassador Videos</h3>
+<p class="text-gray-600 mb-4">Featured in multiple Virginia Tech ECE recruitment and advice videos, sharing experiences and guidance with prospective students.</p>
+<div class="flex flex-col sm:flex-row gap-4 justify-center">
+<a target="_blank" rel="noopener noreferrer" class="inline-flex items-center text-vt-maroon hover:text-vt-maroon/80 font-medium" href="https://www.youtube.com/watch?v=example1">Student Spotlight Video<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-external-link w-4 h-4 ml-1" aria-hidden="true">
+<path d="M15 3h6v6">
+</path>
+<path d="M10 14 21 3">
+</path>
+<path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6">
+</path>
+</svg>
+</a>
+<a target="_blank" rel="noopener noreferrer" class="inline-flex items-center text-vt-maroon hover:text-vt-maroon/80 font-medium" href="https://www.youtube.com/watch?v=example2">Advice for Incoming Students<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-external-link w-4 h-4 ml-1" aria-hidden="true">
+<path d="M15 3h6v6">
+</path>
+<path d="M10 14 21 3">
+</path>
+<path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6">
+</path>
+</svg>
+</a>
+</div>
+</div>
+</section>
+</div>
+</div>
+</main>
+<footer class="bg-gray-900 text-white">
+<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+<div class="grid grid-cols-1 md:grid-cols-3 gap-8">
+<div>
+<h3 class="text-lg font-semibold mb-4">Contact</h3>
+<div class="space-y-3">
+<div class="flex items-center space-x-3">
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-mail w-5 h-5 text-gray-400" aria-hidden="true">
+<path d="m22 7-8.991 5.727a2 2 0 0 1-2.009 0L2 7">
+</path>
+<rect x="2" y="4" width="20" height="16" rx="2">
+</rect>
+</svg>
+<a href="mailto:yuri.braga@carefuseai.com" class="hover:text-carefuse-teal transition-colors">yuri.braga@carefuseai.com</a>
+</div>
+<div class="flex items-center space-x-3">
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-phone w-5 h-5 text-gray-400" aria-hidden="true">
+<path d="M13.832 16.568a1 1 0 0 0 1.213-.303l.355-.465A2 2 0 0 1 17 15h3a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2A18 18 0 0 1 2 4a2 2 0 0 1 2-2h3a2 2 0 0 1 2 2v3a2 2 0 0 1-.8 1.6l-.468.351a1 1 0 0 0-.292 1.233 14 14 0 0 0 6.392 6.384">
+</path>
+</svg>
+<a href="tel:+15409984267" class="hover:text-carefuse-teal transition-colors">+1 (540) 998-4267</a>
+</div>
+</div>
+</div>
+<div>
+<h3 class="text-lg font-semibold mb-4">Quick Links</h3>
+<div class="space-y-2">
+<a class="block hover:text-carefuse-teal transition-colors" href="/about/">About</a>
+<a class="block hover:text-carefuse-teal transition-colors" href="/carefuse/">CareFuse</a>
+<a class="block hover:text-carefuse-teal transition-colors" href="/academics/">Academics</a>
+<a class="block hover:text-carefuse-teal transition-colors" href="/contact/">Contact</a>
+<a class="block hover:text-carefuse-teal transition-colors" href="/resume/">Resume</a>
+</div>
+</div>
+<div>
+<h3 class="text-lg font-semibold mb-4">Connect</h3>
+<div class="space-y-2">
+<a href="https://www.linkedin.com/in/yuribraga1/" target="_blank" rel="noopener noreferrer" class="flex items-center space-x-2 text-gray-400 hover:text-carefuse-teal transition-colors">
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-linkedin w-5 h-5" aria-hidden="true">
+<path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z">
+</path>
+<rect width="4" height="12" x="2" y="9">
+</rect>
+<circle cx="4" cy="4" r="2">
+</circle>
+</svg>
+<span>LinkedIn</span>
+</a>
+<a href="https://carefuseai.com" target="_blank" rel="noopener noreferrer" class="block text-gray-400 hover:text-vt-orange transition-colors">CareFuse Website</a>
+</div>
+</div>
+</div>
+<div class="border-t border-gray-800 mt-8 pt-8 text-center">
+<p class="text-gray-400 text-sm">© 2024 Yuri Braga. All rights reserved. •<span class="ml-1">Built with Next.js and Tailwind CSS</span>
+</p>
+</div>
+</div>
+</footer>
+</body>
+</html>
+

--- a/carefuse/index.html
+++ b/carefuse/index.html
@@ -2,14 +2,21 @@
 <html lang="en">
 <head>
 <meta charSet="utf-8"/>
-<!-- Next.js client runtime removed for static GitHub Pages export. Client-side bootstrapping scripts omitted. -->
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<link rel="stylesheet" href="/_next/static/css/28d069147ec3b886.css" data-precedence="next"/>
+<title>Yuri Braga - Computer Engineer &amp; Healthcare AI Researcher</title>
+<meta name="description" content="Computer Engineer at Virginia Tech specializing in healthcare AI, machine learning for patient safety, and explainable AI models for clinical decision support."/>
+<meta name="author" content="Yuri Braga"/>
+<meta name="keywords" content="machine learning, healthcare AI, explainable AI, surgical outcomes, Total Knee Arthroplasty, MCID, patient safety, Virginia Tech, computer engineering"/>
+<meta property="og:title" content="Yuri Braga - Computer Engineer &amp; Healthcare AI Researcher"/>
+<meta property="og:description" content="Computer Engineer at Virginia Tech specializing in healthcare AI, machine learning for patient safety, and explainable AI models for clinical decision support."/>
+<meta property="og:url" content="https://yuribraga.dev/"/>
 <meta property="og:site_name" content="Yuri Braga Portfolio"/>
 <meta property="og:type" content="website"/>
 <meta name="twitter:card" content="summary_large_image"/>
 <meta name="twitter:title" content="Yuri Braga - Computer Engineer &amp; Healthcare AI Researcher"/>
 <meta name="twitter:description" content="Computer Engineer at Virginia Tech specializing in healthcare AI and patient safety."/>
 <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="16x16"/>
-<!-- Next.js client scripts removed for static GitHub Pages export -->
 </head>
 <body class="font-sans antialiased">
 <nav class="bg-white/95 backdrop-blur-sm border-b border-gray-200 sticky top-0 z-50">
@@ -20,10 +27,30 @@
 <span class="text-xl font-bold text-gray-900">Yuri Braga</span>
 </a>
 </div>
-<!-- Next.js client runtime removed for static GitHub Pages export. The page remains fully static; restore Next runtime for client navigation/hydration if required. -->
-
+<div class="hidden md:flex items-center space-x-8">
+<a class="text-gray-700 hover:text-carefuse-teal transition-colors duration-200 text-sm font-medium" href="/">Home</a>
+<a class="text-gray-700 hover:text-carefuse-teal transition-colors duration-200 text-sm font-medium" href="/about/">About</a>
+<a class="text-gray-700 hover:text-carefuse-teal transition-colors duration-200 text-sm font-medium" href="/carefuse/">CareFuse</a>
+<a class="text-gray-700 hover:text-carefuse-teal transition-colors duration-200 text-sm font-medium" href="/experience/">Experience</a>
+<a class="text-gray-700 hover:text-carefuse-teal transition-colors duration-200 text-sm font-medium" href="/academics/">Academics</a>
+<a class="text-gray-700 hover:text-carefuse-teal transition-colors duration-200 text-sm font-medium" href="/campus-involvement/">Campus</a>
 <a class="text-gray-700 hover:text-carefuse-teal transition-colors duration-200 text-sm font-medium" href="/personal/">Personal</a>
-<!-- Next.js client runtime removed for static GitHub Pages export. Client-side bootstrapping scripts omitted. -->
+<a class="text-gray-700 hover:text-carefuse-teal transition-colors duration-200 text-sm font-medium" href="/recommendations/">Recommendations</a>
+<a class="text-gray-700 hover:text-carefuse-teal transition-colors duration-200 text-sm font-medium" href="/contact/">Contact</a>
+<a class="inline-flex items-center space-x-1 bg-carefuse-teal text-white px-4 py-2 rounded-md hover:bg-carefuse-teal/90 transition-colors duration-200 text-sm font-medium" href="/resume/">
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-download w-4 h-4" aria-hidden="true">
+<path d="M12 15V3">
+</path>
+<path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4">
+</path>
+<path d="m7 10 5 5 5-5">
+</path>
+</svg>
+<span>Resume</span>
+</a>
+</div>
+<div class="md:hidden">
+<button class="text-gray-700 hover:text-carefuse-teal focus:outline-none focus:text-carefuse-teal">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-menu w-6 h-6" aria-hidden="true">
 <path d="M4 5h16">
 </path>
@@ -425,7 +452,6 @@
 </div>
 </div>
 </footer>
-<!-- Next.js client runtime removed for static GitHub Pages export. Client-side bootstrapping scripts omitted. -->
 </body>
 </html>
 


### PR DESCRIPTION
## Summary
- replace the academics route RSC payload with the exported static HTML so the page no longer triggers server errors
- restore the complete Campus Involvement markup and mirror it into index.txt for GitHub Pages compatibility
- regenerate the CareFuse HTML from the backup, keeping the shared stylesheet so the page renders with its intended styling

## Testing
- python3 -m http.server 8000

------
https://chatgpt.com/codex/tasks/task_e_68de751b10208321806d653d1a20b1d4