### PR TITLE
Add next-page navigation and restore CareFuse details

### DIFF
--- a/about/index.html
+++ b/about/index.html
@@ -146,29 +146,6 @@
 <h2 class="text-2xl font-bold mb-4">Mission Statement</h2>
 <p class="text-lg leading-relaxed">To revolutionize patient care through the power of artificial intelligence and data-driven insights, ensuring that every medical decision is grounded in evidence and prioritizes patient safety above all else.</p>
 </div>
-<div class="text-center">
-<h2 class="text-2xl font-bold text-gray-900 mb-6">Ready to learn more about my work?</h2>
-<div class="flex flex-col sm:flex-row gap-4 justify-center">
-<a class="inline-flex items-center space-x-2 bg-vt-maroon text-white px-6 py-3 rounded-lg hover:bg-vt-maroon/90 transition-colors font-medium" href="/carefuse/">
-<span>Explore CareFuse</span>
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-arrow-right w-4 h-4" aria-hidden="true">
-<path d="M5 12h14">
-</path>
-<path d="m12 5 7 7-7 7">
-</path>
-</svg>
-</a>
-<a class="inline-flex items-center space-x-2 border-2 border-vt-maroon text-vt-maroon px-6 py-3 rounded-lg hover:bg-vt-maroon hover:text-white transition-colors font-medium" href="/contact/">
-<span>Get in Touch</span>
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-arrow-right w-4 h-4" aria-hidden="true">
-<path d="M5 12h14">
-</path>
-<path d="m12 5 7 7-7 7">
-</path>
-</svg>
-</a>
-</div>
-</div>
 </div>
 <div class="mt-12 text-center">
 <a class="inline-flex items-center bg-carefuse-teal text-white px-6 py-3 rounded-lg hover:bg-carefuse-teal/90 transition-colors font-medium" href="/carefuse/">Next: CareFuse<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-arrow-right w-4 h-4 ml-2" aria-hidden="true">

--- a/carefuse/index.html
+++ b/carefuse/index.html
@@ -4,6 +4,21 @@
 <meta charSet="utf-8"/>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <link rel="stylesheet" href="/_next/static/css/28d069147ec3b886.css" data-precedence="next"/>
+<link rel="preload" as="script" fetchPriority="low" href="/_next/static/chunks/webpack-616e068a201ad621.js"/>
+<script src="/_next/static/chunks/fd9d1056-357a9aa7cf7b0906.js" async="">
+</script>
+<script src="/_next/static/chunks/117-5f9b74e563f2720e.js" async="">
+</script>
+<script src="/_next/static/chunks/main-app-ff95fd5ca27d98e6.js" async="">
+</script>
+<script src="/_next/static/chunks/972-e6acae3a74adc8b1.js" async="">
+</script>
+<script src="/_next/static/chunks/878-a2053ba011a8f515.js" async="">
+</script>
+<script src="/_next/static/chunks/app/carefuse/page-af51f567578b7af3.js" async="">
+</script>
+<script src="/_next/static/chunks/app/layout-96060b751e953699.js" async="">
+</script>
 <title>Yuri Braga - Computer Engineer &amp; Healthcare AI Researcher</title>
 <meta name="description" content="Computer Engineer at Virginia Tech specializing in healthcare AI, machine learning for patient safety, and explainable AI models for clinical decision support."/>
 <meta name="author" content="Yuri Braga"/>
@@ -17,6 +32,8 @@
 <meta name="twitter:title" content="Yuri Braga - Computer Engineer &amp; Healthcare AI Researcher"/>
 <meta name="twitter:description" content="Computer Engineer at Virginia Tech specializing in healthcare AI and patient safety."/>
 <link rel="icon" href="/favicon.ico" type="image/x-icon" sizes="16x16"/>
+<script src="/_next/static/chunks/polyfills-42372ed130431b0a.js" noModule="">
+</script>
 </head>
 <body class="font-sans antialiased">
 <nav class="bg-white/95 backdrop-blur-sm border-b border-gray-200 sticky top-0 z-50">
@@ -50,7 +67,7 @@
 </a>
 </div>
 <div class="md:hidden">
-<button id="mobile-menu-button" aria-expanded="false" aria-controls="mobile-menu" class="text-gray-700 hover:text-carefuse-teal focus:outline-none focus:text-carefuse-teal">
+<button class="text-gray-700 hover:text-carefuse-teal focus:outline-none focus:text-carefuse-teal">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-menu w-6 h-6" aria-hidden="true">
 <path d="M4 5h16">
 </path>
@@ -63,20 +80,7 @@
 </div>
 </div>
 </div>
- </nav>
-<div id="mobile-menu" class="md:hidden hidden bg-white border-b border-gray-200 transition-opacity duration-200 ease-in-out opacity-0">
-	<div class="px-4 pt-4 pb-4 space-y-2">
-		<a class="block text-gray-700 py-2" href="/">Home</a>
-		<a class="block text-gray-700 py-2" href="/about/">About</a>
-		<a class="block text-gray-700 py-2" href="/carefuse/">CareFuse</a>
-		<a class="block text-gray-700 py-2" href="/experience/">Experience</a>
-		<a class="block text-gray-700 py-2" href="/academics/">Academics</a>
-		<a class="block text-gray-700 py-2" href="/campus-involvement/">Campus</a>
-		<a class="block text-gray-700 py-2" href="/personal/">Personal</a>
-		<a class="block text-gray-700 py-2" href="/recommendations/">Recommendations</a>
-		<a class="block text-gray-700 py-2" href="/contact/">Contact</a>
-	</div>
-</div>
+</nav>
 <main class="min-h-screen">
 <div class="py-20 bg-white">
 <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -305,5 +309,185 @@
 </svg>Implemented SHAP explanations for clinical transparency</li>
 <li class="flex items-start">
 <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-circle-check-big w-4 h-4 text-carefuse-teal mr-2 mt-1 flex-shrink-0" aria-hidden="true">
-<path d="M21.801 10A10 0
+<path d="M21.801 10A10 10 0 1 1 17 3.335">
+</path>
+<path d="m9 11 3 3L22 4">
+</path>
+</svg>Achieved ~0.93 AUC with robust calibration techniques</li>
+
+<!-- Added highlight bullets per user request -->
+<li class="flex items-start">
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-circle-check-big w-4 h-4 text-carefuse-teal mr-2 mt-1 flex-shrink-0" aria-hidden="true">
+<path d="M21.801 10A10 10 0 1 1 17 3.335"></path>
+<path d="m9 11 3 3L22 4"></path>
+</svg>Organized a large OAI dataset for internal model development and analysis</li>
+<li class="flex items-start">
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-circle-check-big w-4 h-4 text-carefuse-teal mr-2 mt-1 flex-shrink-0" aria-hidden="true">
+<path d="M21.801 10A10 10 0 1 1 17 3.335">
+</path>
+<path d="m9 11 3 3L22 4">
+</path>
+</svg>Applied propensity weighting for causal robustness</li>
+					</ul>
+				</div>
+				<div>
+				<h3 class="text-lg font-semibold text-carefuse-navy mb-3">Platform &amp; Deployment</h3>
+				<ul class="space-y-2 text-carefuse-gray">
+<li class="flex items-start">
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-circle-check-big w-4 h-4 text-carefuse-teal mr-2 mt-1 flex-shrink-0" aria-hidden="true">
+<path d="M21.801 10A10 10 0 1 1 17 3.335">
+</path>
+<path d="m9 11 3 3L22 4">
+</path>
+</svg>Built FastAPI + Docker deployment infrastructure</li>
+<li class="flex items-start">
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-circle-check-big w-4 h-4 text-carefuse-teal mr-2 mt-1 flex-shrink-0" aria-hidden="true">
+<path d="M21.801 10A10 10 0 1 1 17 3.335"></path>
+<path d="m9 11 3 3L22 4"></path>
+</svg>Developed dockerized RESTful APIs for model serving and internal tooling</li>
+<li class="flex items-start">
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-circle-check-big w-4 h-4 text-carefuse-teal mr-2 mt-1 flex-shrink-0" aria-hidden="true">
+<path d="M21.801 10A10 10 0 1 1 17 3.335"></path>
+<path d="m9 11 3 3L22 4"></path>
+</svg>Designed and implemented the company's website and public-facing UI</li>
+<li class="flex items-start">
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-circle-check-big w-4 h-4 text-carefuse-teal mr-2 mt-1 flex-shrink-0" aria-hidden="true">
+<path d="M21.801 10A10 10 0 1 1 17 3.335">
+</path>
+<path d="m9 11 3 3L22 4">
+</path>
+</svg>Designed FHIR R4 and Da Vinci PAS integration</li>
+<li class="flex items-start">
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-circle-check-big w-4 h-4 text-carefuse-teal mr-2 mt-1 flex-shrink-0" aria-hidden="true">
+<path d="M21.801 10A10 10 0 1 1 17 3.335">
+</path>
+<path d="m9 11 3 3L22 4">
+</path>
+</svg>Ensured FDA non-device CDS exemption compliance</li>
+<li class="flex items-start">
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-circle-check-big w-4 h-4 text-carefuse-teal mr-2 mt-1 flex-shrink-0" aria-hidden="true">
+<path d="M21.801 10A10 10 0 1 1 17 3.335">
+</path>
+<path d="m9 11 3 3L22 4">
+</path>
+</svg>Implemented multi-seed holdout validation</li>
+					</ul>
+				</div>
+</div>
+</div>
+</div>
+</section>
+<section class="mb-20">
+<div class="rounded-lg border border-gray-200 shadow-sm hover:shadow-md hover:border-gray-300 transition-all duration-200 bg-gradient-to-br from-carefuse-navy to-carefuse-teal text-white">
+<div class="p-8 text-center">
+<h2 class="text-2xl font-bold mb-4">Impact &amp; Vision</h2>
+<p class="text-lg leading-relaxed mb-6">CareFuse represents my commitment to using AI for patient safety and clinical transparency. By providing explainable predictions and seamless workflow integration, we&#x27;re helping healthcare providers make evidence-based decisions that prioritize patient outcomes over volume.</p>
+<div class="grid grid-cols-1 md:grid-cols-3 gap-6 text-center">
+<div>
+<div class="text-3xl font-bold mb-2">38%</div>
+<div class="text-sm opacity-90">Avoidable TKAs with structured care</div>
+</div>
+<div>
+<div class="text-3xl font-bold mb-2">~0.93</div>
+<div class="text-sm opacity-90">AUC for outcome prediction</div>
+</div>
+<div>
+<div class="text-3xl font-bold mb-2">100%</div>
+<div class="text-sm opacity-90">Transparent, explainable decisions</div>
+</div>
+</div>
+</div>
+</div>
+</section>
+<div class="mt-12 text-center" style="margin-bottom:2.25rem;">
+<a class="inline-flex items-center bg-carefuse-teal text-white px-6 py-3 rounded-lg hover:bg-carefuse-teal/90 transition-colors font-medium" href="/experience/">Next: Experience<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-arrow-right w-4 h-4 ml-2" aria-hidden="true">
+<path d="M5 12h14">
+</path>
+<path d="m12 5 7 7-7 7">
+</path>
+</svg>
+</a>
+</div>
+</div>
+</div>
+</main>
+    <script>
+      (function(){
+        var btn = document.getElementById('mobile-menu-button');
+        var menu = document.getElementById('mobile-menu');
+        if(!btn || !menu) return;
+        btn.addEventListener('click', function(){
+          var open = menu.classList.toggle('hidden') === false;
+          btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+        });
+      })();
+    </script>
+
+<footer class="bg-gray-900 text-white">
+<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+<div class="grid grid-cols-1 md:grid-cols-3 gap-8">
+<div>
+<h3 class="text-lg font-semibold mb-4">Contact</h3>
+<div class="space-y-3">
+<div class="flex items-center space-x-3">
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-mail w-5 h-5 text-gray-400" aria-hidden="true">
+<path d="m22 7-8.991 5.727a2 2 0 0 1-2.009 0L2 7">
+</path>
+<rect x="2" y="4" width="20" height="16" rx="2">
+</rect>
+</svg>
+<a href="mailto:yuri.braga@carefuseai.com" class="hover:text-carefuse-teal transition-colors">yuri.braga@carefuseai.com</a>
+</div>
+<div class="flex items-center space-x-3">
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-phone w-5 h-5 text-gray-400" aria-hidden="true">
+<path d="M13.832 16.568a1 1 0 0 0 1.213-.303l.355-.465A2 2 0 0 1 17 15h3a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2A18 18 0 0 1 2 4a2 2 0 0 1 2-2h3a2 2 0 0 1 2 2v3a2 2 0 0 1-.8 1.6l-.468.351a1 1 0 0 0-.292 1.233 14 14 0 0 0 6.392 6.384">
+</path>
+</svg>
+<a href="tel:+15409984267" class="hover:text-carefuse-teal transition-colors">+1 (540) 998-4267</a>
+</div>
+</div>
+</div>
+<div>
+<h3 class="text-lg font-semibold mb-4">Quick Links</h3>
+<div class="space-y-2">
+<a class="block hover:text-carefuse-teal transition-colors" href="/about/">About</a>
+<a class="block hover:text-carefuse-teal transition-colors" href="/carefuse/">CareFuse</a>
+<a class="block hover:text-carefuse-teal transition-colors" href="/academics/">Academics</a>
+<a class="block hover:text-carefuse-teal transition-colors" href="/contact/">Contact</a>
+<a class="block hover:text-carefuse-teal transition-colors" href="/resume/">Resume</a>
+</div>
+</div>
+<div>
+<h3 class="text-lg font-semibold mb-4">Connect</h3>
+<div class="space-y-2">
+<a href="https://www.linkedin.com/in/yuribraga1/" target="_blank" rel="noopener noreferrer" class="flex items-center space-x-2 text-gray-400 hover:text-carefuse-teal transition-colors">
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-linkedin w-5 h-5" aria-hidden="true">
+<path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z">
+</path>
+<rect width="4" height="12" x="2" y="9">
+</rect>
+<circle cx="4" cy="4" r="2">
+</circle>
+</svg>
+<span>LinkedIn</span>
+</a>
+<a href="https://carefuseai.com" target="_blank" rel="noopener noreferrer" class="block text-gray-400 hover:text-vt-orange transition-colors">CareFuse Website</a>
+</div>
+</div>
+</div>
+<div class="border-t border-gray-800 mt-8 pt-8 text-center">
+<p class="text-gray-400 text-sm">© 2024 Yuri Braga. All rights reserved. •<span class="ml-1">Built with Next.js and Tailwind CSS</span>
+</p>
+</div>
+</div>
+</footer>
+<script src="/_next/static/chunks/webpack-616e068a201ad621.js" async="">
+</script>
+<script>(self.__next_f=self.__next_f||[]).push([0]);self.__next_f.push([2,null])</script>
+<script>self.__next_f.push([1,"1:HL[\"/_next/static/css/28d069147ec3b886.css\",\"style\"]\n"])</script>
+<script>self.__next_f.push([1,"2:I[2846,[],\"\"]\n4:I[5878,[\"972\",\"static/chunks/972-e6acae3a74adc8b1.js\",\"878\",\"static/chunks/878-a2053ba011a8f515.js\",\"346\",\"static/chunks/app/carefuse/page-af51f567578b7af3.js\"],\"Image\"]\n5:I[2972,[\"972\",\"static/chunks/972-e6acae3a74adc8b1.js\",\"878\",\"static/chunks/878-a2053ba011a8f515.js\",\"346\",\"static/chunks/app/carefuse/page-af51f567578b7af3.js\"],\"\"]\n6:I[4707,[],\"\"]\n7:I[6423,[],\"\"]\n8:I[3064,[\"972\",\"static/chunks/972-e6acae3a74adc8b1.js\",\"878\",\"static/chunks/878-a2053ba011a8f515.js\",\"185\",\"static/chunks/app/layout-96060b751e953699.js\"],\"default\"]\na:I[1060,[],\"\"]\nb:[]\n"])</script>
+<script>self.__next_f.push([1,"0:[\"$\",\"$L2\",null,{\"buildId\":\"TvnfXHU6nbvB6OIZi7NfN\",\"assetPrefix\":\"\",\"urlParts\":[\"\",\"carefuse\",\"\"],\"initialTree\":[\"\",{\"children\":[\"carefuse\",{\"children\":[\"__PAGE__\",{}]}]},\"$undefined\",\"$undefined\",true],\"initialSeedData\":[\"\",{\"children\":[\"carefuse\",{\"children\":[\"__PAGE__\",{},[[\"$L3\",[\"$\",\"div\",null,{\"className\":\"py-20 bg-white\",\"children\":[\"$\",\"div\",null,{\"className\":\"max-w-7xl mx-auto px-4 sm:px-6 lg:px-8\",\"children\":[[\"$\",\"div\",null,{\"className\":\"text-center mb-16\",\"children\":[[\"$\",\"div\",null,{\"className\":\"flex justify-center mb-6\",\"children\":[\"$\",\"$L4\",null,{\"src\":\"/images/carefuse_logo.png\",\"alt\":\"CareFuse\",\"width\":80,\"height\":80,\"className\":\"w-20 h-20\"}]}],[\"$\",\"h1\",null,{\"className\":\"text-4xl sm:text-5xl font-bold text-carefuse-navy mb-6\",\"children\":\"CareFuse\"}],[\"$\",\"p\",null,{\"className\":\"text-xl text-carefuse-gray max-w-3xl mx-auto mb-8\",\"children\":\"Transparent AI for Hip \u0026 Knee Prior Authorization. Per-member clinical predictions with SHAP explanations, built for InterQual/MCG workflows and HL7 FHIR PAS.\"}],[\"$\",\"a\",null,{\"href\":\"https://carefuseai.com\",\"target\":\"_blank\",\"rel\":\"noopener noreferrer\",\"className\":\"inline-flex items-center bg-carefuse-teal text-white px-6 py-3 rounded-lg hover:bg-carefuse-teal/90 transition-colors font-medium\",\"children\":[[\"$\",\"svg\",null,{\"xmlns\":\"http://www.w3.org/2000/svg\",\"width\":24,\"height\":24,\"viewBox\":\"0 0 24 24\",\"fill\":\"none\",\"stroke\":\"currentColor\",\"strokeWidth\":2,\"strokeLinecap\":\"round\",\"strokeLinejoin\":\"round\",\"className\":\"lucide lucide-external-link w-4 h-4 mr-2\",\"aria-hidden\":\"true\",\"children\":[[\"$\",\"path\",\"1q9fwt\",{\"d\":\"M15 3h6v6\"}],[\"$\",\"path\",\"gplh6r\",{\"d\":\"M10 14 21 3\"}],[\"$\",\"path\",\"a6xqqp\",{\"d\":\"M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6\"}],\"$undefined\"]}],\"Visit CareFuse Website\"]}]]}],[\"$\",\"section\",null,{\"className\":\"mb-20\",\"children\":[[\"$\",\"div\",null,{\"className\":\"text-center mb-12\",\"children\":[[\"$\",\"h2\",null,{\"className\":\"text-3xl font-bold text-carefuse-navy mb-4\",\"children\":\"The Perfect Storm: Four Converging Healthcare Forces\"}],[\"$\",\"p\",null,{\"className\":\"text-lg text-carefuse-gray max-w-4xl mx-auto\",\"children\":\"The U.S. healthcare system is experiencing unprecedented regulatory convergence that's transforming how knee replacement decisions are made, measured, and governed.\"}]]}],[\"$\",\"div\",null,{\"className\":\"grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6\",\"children\":[[\"$\",\"div\",null,{\"className\":\"bg-white rounded-lg border shadow-sm hover:shadow-md duration-200 text-center border-carefuse-teal/20 hover:border-carefuse-teal/50 transition-colors\",\"children\":[[\"$\",\"div\",null,{\"className\":\"p-6 pb-4\",\"children\":[[\"$\",\"div\",null,{\"className\":\"w-16 h-16 bg-carefuse-teal/10 rounded-full flex items-center justify-center mx-auto mb-4\",\"children\":[\"$\",\"svg\",null,{\"xmlns\":\"http://www.w3.org/2000/svg\",\"width\":24,\"height\":24,\"viewBox\":\"0 0 24 24\",\"fill\":\"none\",\"stroke\":\"currentColor\",\"strokeWidth\":2,\"strokeLinecap\":\"round\",\"strokeLinejoin\":\"round\",\"className\":\"lucide lucide-chart-column w-8 h-8 text-carefuse-teal\",\"aria-hidden\":\"true\",\"children\":[[\"$\",\"path\",\"c24i48\",{\"d\":\"M3 3v16a2 2 0 0 0 2 2h16\"}],[\"$\",\"path\",\"2bz60n\",{\"d\":\"M18 17V9\"}],[\"$\",\"path\",\"1frdt8\",{\"d\":\"M13 17V5\"}],[\"$\",\"path\",\"17ska0\",{\"d\":\"M8 17v-3\"}],\"$undefined\"]}]}],[\"$\",\"h3\",null,{\"className\":\"font-semibold mb-2 text-carefuse-navy text-lg\",\"children\":\"The Accountability Challenge\"}]]}],[\"$\",\"div\",null,{\"className\":\"px-6 pb-6\",\"children\":[[\"$\",\"div\",null,{\"className\":\"text-3xl font-bold text-carefuse-teal mb-2\",\"children\":\"24%\"}],[\"$\",\"p\",null,{\"className\":\"text-sm text-carefuse-gray\",\"children\":\"APU Reduction Penalty for non-compliance with PROMs collection\"}]]}]]}],[\"$\",\"div\",null,{\"className\":\"bg-white rounded-lg border shadow-sm hover:shadow-md duration-200 text-center border-carefuse-teal/20 hover:border-carefuse-teal/50 transition-colors\",\"children\":[[\"$\",\"div\",null,{\"className\":\"p-6 pb-4\",\"children\":[[\"$\",\"div\",null,{\"className\":\"w-16 h-16 bg-carefuse-teal/10 rounded-full flex items-center justify-center mx-auto mb-4\",\"children\":[\"$\",\"svg\",null,{\"xmlns\":\"http://www.w3.org/2000/svg\",\"width\":24,\"height\":24,\"viewBox\":\"0 0 24 24\",\"fill\":\"none\",\"stroke\":\"currentColor\",\"strokeWidth\":2,\"strokeLinecap\":\"round\",\"strokeLinejoin\":\"round\",\"className\":\"lucide lucide-users w-8 h-8 text-carefuse-teal\",\"aria-hidden\":\"true\",\"children\":[[\"$\",\"path\",\"1yyitq\",{\"d\":\"M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2\"}],[\"$\",\"path\",\"16gr8j\",{\"d\":\"M16 3.128a4 4 0 0 1 0 7.744\"}],[\"$\",\"path\",\"kshegd\",{\"d\":\"M22 21v-2a4 4 0 0 0-3-3.87\"}],[\"$\",\"circle\",\"nufk8\",{\"cx\":\"9\",\"cy\":\"7\",\"r\":\"4\"}],\"$undefined\"]}]}],[\"$\",\"h3\",null,{\"className\":\"font-semibold mb-2 text-carefuse-navy text-lg\",\"children\":\"The Subjectivity Problem\"}]]}],[\"$\",\"div\",null,{\"className\":\"px-6 pb-6\",\"children\":[[\"$\",\"div\",null,{\"className\":\"text-3xl font-bold text-carefuse-teal mb-2\",\"children\":\"High\"}],[\"$\",\"p\",null,{\"className\":\"text-sm text-carefuse-gray\",\"children\":\"Physician Variation - Significant disagreement on TKA indications\"}]]}]]}],[\"$\",\"div\",null,{\"className\":\"bg-white rounded-lg border shadow-sm hover:shadow-md duration-200 text-center border-carefuse-teal/20 hover:border-carefuse-teal/50 transition-colors\",\"children\":[[\"$\",\"div\",null,{\"className\":\"p-6 pb-4\",\"children\":[[\"$\",\"div\",null,{\"className\":\"w-16 h-16 bg-carefuse-teal/10 rounded-full flex items-center justify-center mx-auto mb-4\",\"children\":[\"$\",\"svg\",null,{\"xmlns\":\"http://www.w3.org/2000/svg\",\"width\":24,\"height\":24,\"viewBox\":\"0 0 24 24\",\"fill\":\"none\",\"stroke\":\"currentColor\",\"strokeWidth\":2,\"strokeLinecap\":\"round\",\"strokeLinejoin\":\"round\",\"className\":\"lucide lucide-shield w-8 h-8 text-carefuse-teal\",\"aria-hidden\":\"true\",\"children\":[[\"$\",\"path\",\"oel41y\",{\"d\":\"M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z\"}],\"$undefined\"]}]}],[\"$\",\"h3\",null,{\"className\":\"font-semibold mb-2 text-carefuse-navy text-lg\",\"children\":\"The Transparency Requirement\"}]]}],[\"$\",\"div\",null,{\"className\":\"px-6 pb-6\",\"children\":[[\"$\",\"div\",null,{\"className\":\"text-3xl font-bold text-carefuse-teal mb-2\",\"children\":\"6\"}],[\"$\",\"p\",null,{\"className\":\"text-sm text-carefuse-gray\",\"children\":\"States with AI Laws requiring physician oversight of AI decisions\"}]]}]]}],[\"$\",\"div\",null,{\"className\":\"bg-white rounded-lg border shadow-sm hover:shadow-md duration-200 text-center border-carefuse-teal/20 hover:border-carefuse-teal/50 transition-colors\",\"children\":[[\"$\",\"div\",null,{\"className\":\"p-6 pb-4\",\"children\":[[\"$\",\"div\",null,{\"className\":\"w-16 h-16 bg-carefuse-teal/10 rounded-full flex items-center justify-center mx-auto mb-4\",\"children\":[\"$\",\"svg\",null,{\"xmlns\":\"http://www.w3.org/2000/svg\",\"width\":24,\"height\":24,\"viewBox\":\"0 0 24 24\",\"fill\":\"none\",\"stroke\":\"currentColor\",\"strokeWidth\":2,\"strokeLinecap\":\"round\",\"strokeLinejoin\":\"round\",\"className\":\"lucide lucide-trending-up w-8 h-8 text-carefuse-teal\",\"aria-hidden\":\"true\",\"children\":[[\"$\",\"path\",\"box55l\",{\"d\":\"M16 7h6v6\"}],[\"$\",\"path\",\"1t1m79\",{\"d\":\"m22 7-8.5 8.5-5-5L2 17\"}],\"$undefined\"]}]}],[\"$\",\"h3\",null,{\"className\":\"font-semibold mb-2 text-carefuse-navy text-lg\",\"children\":\"The Evidence Gap Problem\"}]]}],[\"$\",\"div\",null,{\"className\":\"px-6 pb-6\",\"children\":[[\"$\",\"div\",null,{\"className\":\"text-3xl font-bold text-carefuse-teal mb-2\",\"children\":\"38%\"}],[\"$\",\"p\",null,{\"className\":\"text-sm text-carefuse-gray\",\"children\":\"TKAs Avoidable with structured conservative care\"}]]}]]}]]}]]}],[\"$\",\"section\",null,{\"className\":\"mb-20\",\"children\":[[\"$\",\"div\",null,{\"className\":\"text-center mb-12\",\"children\":[[\"$\",\"h2\",null,{\"className\":\"text-3xl font-bold text-carefuse-navy mb-4\",\"children\":\"CareFuse Solution\"}],[\"$\",\"p\",null,{\"className\":\"text-lg text-carefuse-gray max-w-4xl mx-auto\",\"children\":\"Our platform addresses these challenges with transparent, explainable AI that integrates seamlessly with existing healthcare workflows while ensuring regulatory compliance.\"}]]}],[\"$\",\"div\",null,{\"className\":\"grid grid-cols-1 md:grid-cols-2 gap-8\",\"children\":[[\"$\",\"div\",null,{\"className\":\"bg-white rounded-lg border shadow-sm hover:shadow-md duration-200 border-carefuse-teal/20 hover:border-carefuse-teal/50 transition-colors\",\"children\":[[\"$\",\"div\",null,{\"className\":\"p-6 pb-4\",\"children\":[\"$\",\"div\",null,{\"className\":\"flex items-center space-x-4\",\"children\":[[\"$\",\"div\",null,{\"className\":\"w-12 h-12 bg-carefuse-teal/10 rounded-lg flex items-center justify-center\",\"children\":[\"$\",\"svg\",null,{\"xmlns\":\"http://www.w3.org/2000/svg\",\"width\":24,\"height\":24,\"viewBox\":\"0 0 24 24\",\"fill\":\"none\",\"stroke\":\"currentColor\",\"strokeWidth\":2,\"strokeLinecap\":\"round\",\"strokeLinejoin\":\"round\",\"className\":\"lucide lucide-database w-6 h-6 text-carefuse-teal\",\"aria-hidden\":\"true\",\"children\":[[\"$\",\"ellipse\",\"msslwz\",{\"cx\":\"12\",\"cy\":\"5\",\"rx\":\"9\",\"ry\":\"3\"}],[\"$\",\"path\",\"1wlel7\",{\"d\":\"M3 5V19A9 3 0 0 0 21 19V5\"}],[\"$\",\"path\",\"mv7ke4\",{\"d\":\"M3 12A9 3 0 0 0 21 12\"}],\"$undefined\"]}]}],[\"$\",\"h3\",null,{\"className\":\"text-xl font-semibold mb-2 text-carefuse-navy\",\"children\":\"FHIR PAS Ready\"}]]}]}],[\"$\",\"div\",null,{\"className\":\"px-6 pb-6\",\"children\":[\"$\",\"p\",null,{\"className\":\"text-carefuse-gray\",\"children\":\"Built for Da Vinci PAS workflows and ePA compliance by 2027\"}]}]]}],[\"$\",\"div\",null,{\"className\":\"bg-white rounded-lg border shadow-sm hover:shadow-md duration-200 border-carefuse-teal/20 hover:border-carefuse-teal/50 transition-colors\",\"children\":[[\"$\",\"div\",null,{\"className\":\"p-6 pb-4\",\"children\":[\"$\",\"div\",null,{\"className\":\"flex items-center space-x-4\",\"children\":[[\"$\",\"div\",null,{\"className\":\"w-12 h-12 bg-carefuse-teal/10 rounded-lg flex items-center justify-center\",\"children\":[\"$\",\"svg\",null,{\"xmlns\":\"http://www.w3.org/2000/svg\",\"width\":24,\"height\":24,\"viewBox\":\"0 0 24 24\",\"fill\":\"none\",\"stroke\":\"currentColor\",\"strokeWidth\":2,\"strokeLinecap\":\"round\",\"strokeLinejoin\":\"round\",\"className\":\"lucide lucide-brain w-6 h-6 text-carefuse-teal\",\"aria-hidden\":\"true\",\"children\":[[\"$\",\"path\",\"adv99a\",{\"d\":\"M12 18V5\"}],[\"$\",\"path\",\"1e3is1\",{\"d\":\"M15 13a4.17 4.17 0 0 1-3-4 4.17 4.17 0 0 1-3 4\"}],[\"$\",\"path\",\"1gqd8o\",{\"d\":\"M17.598 6.5A3 3 0 1 0 12 5a3 3 0 1 0-5.598 1.5\"}],[\"$\",\"path\",\"iwvgf7\",{\"d\":\"M17.997 5.125a4 4 0 0 1 2.526 5.77\"}],[\"$\",\"path\",\"efp6ie\",{\"d\":\"M18 18a4 4 0 0 0 2-7.464\"}],[\"$\",\"path\",\"1gq6am\",{\"d\":\"M19.967 17.483A4 4 0 1 1 12 18a4 4 0 1 1-7.967-.517\"}],[\"$\",\"path\",\"k1g0md\",{\"d\":\"M6 18a4 4 0 0 1-2-7.464\"}],[\"$\",\"path\",\"q97ue3\",{\"d\":\"M6.003 5.125a4 4 0 0 0-2.526 5.77\"}],\"$undefined\"]}]}],[\"$\",\"h3\",null,{\"className\":\"text-xl font-semibold mb-2 text-carefuse-navy\",\"children\":\"SHAP Explainable\"}]]}]}],[\"$\",\"div\",null,{\"className\":\"px-6 pb-6\",\"children\":[\"$\",\"p\",null,{\"className\":\"text-carefuse-gray\",\"children\":\"Transparent AI with per-member clinical explanations\"}]}]]}],[\"$\",\"div\",null,{\"className\":\"bg-white rounded-lg border shadow-sm hover:shadow-md duration-200 border-carefuse-teal/20 hover:border-carefuse-teal/50 transition-colors\",\"children\":[[\"$\",\"div\",null,{\"className\":\"p-6 pb-4\",\"children\":[\"$\",\"div\",null,{\"className\":\"flex items-center space-x-4\",\"children\":[[\"$\",\"div\",null,{\"className\":\"w-12 h-12 bg-carefuse-teal/10 rounded-lg flex items-center justify-center\",\"children\":[\"$\",\"svg\",null,{\"xmlns\":\"http://www.w3.org/2000/svg\",\"width\":24,\"height\":24,\"viewBox\":\"0 0 24 24\",\"fill\":\"none\",\"stroke\":\"currentColor\",\"strokeWidth\":2,\"strokeLinecap\":\"round\",\"strokeLinejoin\":\"round\",\"className\":\"lucide lucide-circle-check-big w-6 h-6 text-carefuse-teal\",\"aria-hidden\":\"true\",\"children\":[[\"$\",\"path\",\"yps3ct\",{\"d\":\"M21.801 10A10 10 0 1 1 17 3.335\"}],[\"$\",\"path\",\"1pflzl\",{\"d\":\"m9 11 3 3L22 4\"}],\"$undefined\"]}]}],[\"$\",\"h3\",null,{\"className\":\"text-xl font-semibold mb-2 text-carefuse-navy\",\"children\":\"InterQual/MCG Compatible\"}]]}]}],[\"$\",\"div\",null,{\"className\":\"px-6 pb-6\",\"children\":[\"$\",\"p\",null,{\"className\":\"text-carefuse-gray\",\"children\":\"Seamless integration with existing UM workflows\"}]}]]}],[\"$\",\"div\",null,{\"className\":\"bg-white rounded-lg border shadow-sm hover:shadow-md duration-200 border-carefuse-teal/20 hover:border-carefuse-teal/50 transition-colors\",\"children\":[[\"$\",\"div\",null,{\"className\":\"p-6 pb-4\",\"children\":[\"$\",\"div\",null,{\"className\":\"flex items-center space-x-4\",\"children\":[[\"$\",\"div\",null,{\"className\":\"w-12 h-12 bg-carefuse-teal/10 rounded-lg flex items-center justify-center\",\"children\":[\"$\",\"svg\",null,{\"xmlns\":\"http://www.w3.org/2000/svg\",\"width\":24,\"height\":24,\"viewBox\":\"0 0 24 24\",\"fill\":\"none\",\"stroke\":\"currentColor\",\"strokeWidth\":2,\"strokeLinecap\":\"round\",\"strokeLinejoin\":\"round\",\"className\":\"lucide lucide-stethoscope w-6 h-6 text-carefuse-teal\",\"aria-hidden\":\"true\",\"children\":[[\"$\",\"path\",\"1539x4\",{\"d\":\"M11 2v2\"}],[\"$\",\"path\",\"1yf1q8\",{\"d\":\"M5 2v2\"}],[\"$\",\"path\",\"rb5t3r\",{\"d\":\"M5 3H4a2 2 0 0 0-2 2v4a6 6 0 0 0 12 0V5a2 2 0 0 0-2-2h-1\"}],[\"$\",\"path\",\"x18d4x\",{\"d\":\"M8 15a6 6 0 0 0 12 0v-3\"}],[\"$\",\"circle\",\"ts1r5v\",{\"cx\":\"20\",\"cy\":\"10\",\"r\":\"2\"}],\"$undefined\"]}]}],[\"$\",\"h3\",null,{\"className\":\"text-xl font-semibold mb-2 text-carefuse-navy\",\"children\":\"FDA Compliant\"}]]}]}],[\"$\",\"div\",null,{\"className\":\"px-6 pb-6\",\"children\":[\"$\",\"p\",null,{\"className\":\"text-carefuse-gray\",\"children\":\"Built under FDA non-device CDS exemption for healthcare compliance\"}]}]]}]]}]]}],[\"$\",\"section\",null,{\"className\":\"mb-20\",\"children\":[\"$\",\"div\",null,{\"className\":\"rounded-lg border shadow-sm hover:shadow-md hover:border-gray-300 transition-all duration-200 bg-carefuse-light border-carefuse-teal/20\",\"children\":[[\"$\",\"div\",null,{\"className\":\"p-6 pb-4 text-center\",\"children\":[[\"$\",\"h3\",null,{\"className\":\"font-semibold mb-2 text-carefuse-navy text-2xl\",\"children\":\"My Role \u0026 Technical Contributions\"}],[\"$\",\"p\",null,{\"className\":\"leading-relaxed text-carefuse-gray\",\"children\":\"Co-founder \u0026 Machine Learning Lead at CareFuse\"}]]}],[\"$\",\"div\",null,{\"className\":\"px-6 pb-6 space-y-6\",\"children\":[\"$\",\"div\",null,{\"className\":\"grid grid-cols-1 md:grid-cols-2 gap-8\",\"children\":[[\"$\",\"div\",null,{\"children\":[[\"$\",\"h3\",null,{\"className\":\"text-lg font-semibold text-carefuse-navy mb-3\",\"children\":\"Machine Learning Development\"}],[\"$\",\"ul\",null,{\"className\":\"space-y-2 text-carefuse-gray\",\"children\":[[\"$\",\"li\",null,{\"className\":\"flex items-start\",\"children\":[[\"$\",\"svg\",null,{\"xmlns\":\"http://www.w3.org/2000/svg\",\"width\":24,\"height\":24,\"viewBox\":\"0 0 24 24\",\"fill\":\"none\",\"stroke\":\"currentColor\",\"strokeWidth\":2,\"strokeLinecap\":\"round\",\"strokeLinejoin\":\"round\",\"className\":\"lucide lucide-circle-check-big w-4 h-4 text-carefuse-teal mr-2 mt-1 flex-shrink-0\",\"aria-hidden\":\"true\",\"children\":[[\"$\",\"path\",\"yps3ct\",{\"d\":\"M21.801 10A10 10 0 1 1 17 3.335\"}],[\"$\",\"path\",\"1pflzl\",{\"d\":\"m9 11 3 3L22 4\"}],\"$undefined\"]}],\"Developed explainable AI models for TKA outcome prediction\"]}],[\"$\",\"li\",null,{\"className\":\"flex items-start\",\"children\":[[\"$\",\"svg\",null,{\"xmlns\":\"http://www.w3.org/2000/svg\",\"width\":24,\"height\":24,\"viewBox\":\"0 0 24 24\",\"fill\":\"none\",\"stroke\":\"currentColor\",\"strokeWidth\":2,\"strokeLinecap\":\"round\",\"strokeLinejoin\":\"round\",\"className\":\"lucide lucide-circle-check-big w-4 h-4 text-carefuse-teal mr-2 mt-1 flex-shrink-0\",\"aria-hidden\":\"true\",\"children\":[[\"$\",\"path\",\"yps3ct\",{\"d\":\"M21.801 10A10 10 0 1 1 17 3.335\"}],[\"$\",\"path\",\"1pflzl\",{\"d\":\"m9 11 3 3L22 4\"}],\"$undefined\"]}],\"Implemented SHAP explanations for clinical transparency\"]}],[\"$\",\"li\",null,{\"className\":\"flex items-start\",\"children\":[[\"$\",\"svg\",null,{\"xmlns\":\"http://www.w3.org/2000/svg\",\"width\":24,\"height\":24,\"viewBox\":\"0 0 24 24\",\"fill\":\"none\",\"stroke\":\"currentColor\",\"strokeWidth\":2,\"strokeLinecap\":\"round\",\"strokeLinejoin\":\"round\",\"className\":\"lucide lucide-circle-check-big w-4 h-4 text-carefuse-teal mr-2 mt-1 flex-shrink-0\",\"aria-hidden\":\"true\",\"children\":[[\"$\",\"path\",\"yps3ct\",{\"d\":\"M21.801 10A10 10 0 1 1 17 3.335\"}],[\"$\",\"path\",\"1pflzl\",{\"d\":\"m9 11 3 3L22 4\"}],\"$undefined\"]}],\"Achieved ~0.93 AUC with robust calibration techniques\"]}],[\"$\",\"li\",null,{\"className\":\"flex items-start\",\"children\":[[\"$\",\"svg\",null,{\"xmlns\":\"http://www.w3.org/2000/svg\",\"width\":24,\"height\":24,\"viewBox\":\"0 0 24 24\",\"fill\":\"none\",\"stroke\":\"currentColor\",\"strokeWidth\":2,\"strokeLinecap\":\"round\",\"strokeLinejoin\":\"round\",\"className\":\"lucide lucide-circle-check-big w-4 h-4 text-carefuse-teal mr-2 mt-1 flex-shrink-0\",\"aria-hidden\":\"true\",\"children\":[[\"$\",\"path\",\"yps3ct\",{\"d\":\"M21.801 10A10 10 0 1 1 17 3.335\"}],[\"$\",\"path\",\"1pflzl\",{\"d\":\"m9 11 3 3L22 4\"}],\"$undefined\"]}],\"Applied propensity weighting for causal robustness\"]}]]}]]}],[\"$\",\"div\",null,{\"children\":[[\"$\",\"h3\",null,{\"className\":\"text-lg font-semibold text-carefuse-navy mb-3\",\"children\":\"Platform \u0026 Deployment\"}],[\"$\",\"ul\",null,{\"className\":\"space-y-2 text-carefuse-gray\",\"children\":[[\"$\",\"li\",null,{\"className\":\"flex items-start\",\"children\":[[\"$\",\"svg\",null,{\"xmlns\":\"http://www.w3.org/2000/svg\",\"width\":24,\"height\":24,\"viewBox\":\"0 0 24 24\",\"fill\":\"none\",\"stroke\":\"currentColor\",\"strokeWidth\":2,\"strokeLinecap\":\"round\",\"strokeLinejoin\":\"round\",\"className\":\"lucide lucide-circle-check-big w-4 h-4 text-carefuse-teal mr-2 mt-1 flex-shrink-0\",\"aria-hidden\":\"true\",\"children\":[[\"$\",\"path\",\"yps3ct\",{\"d\":\"M21.801 10A10 10 0 1 1 17 3.335\"}],[\"$\",\"path\",\"1pflzl\",{\"d\":\"m9 11 3 3L22 4\"}],\"$undefined\"]}],\"Built FastAPI + Docker deployment infrastructure\"]}],[\"$\",\"li\",null,{\"className\":\"flex items-start\",\"children\":[[\"$\",\"svg\",null,{\"xmlns\":\"http://www.w3.org/2000/svg\",\"width\":24,\"height\":24,\"viewBox\":\"0 0 24 24\",\"fill\":\"none\",\"stroke\":\"currentColor\",\"strokeWidth\":2,\"strokeLinecap\":\"round\",\"strokeLinejoin\":\"round\",\"className\":\"lucide lucide-circle-check-big w-4 h-4 text-carefuse-teal mr-2 mt-1 flex-shrink-0\",\"aria-hidden\":\"true\",\"children\":[[\"$\",\"path\",\"yps3ct\",{\"d\":\"M21.801 10A10 10 0 1 1 17 3.335\"}],[\"$\",\"path\",\"1pflzl\",{\"d\":\"m9 11 3 3L22 4\"}],\"$undefined\"]}],\"Designed FHIR R4 and Da Vinci PAS integration\"]}],[\"$\",\"li\",null,{\"className\":\"flex items-start\",\"children\":[[\"$\",\"svg\",null,{\"xmlns\":\"http://www.w3.org/2000/svg\",\"width\":24,\"height\":24,\"viewBox\":\"0 0 24 24\",\"fill\":\"none\",\"stroke\":\"currentColor\",\"strokeWidth\":2,\"strokeLinecap\":\"round\",\"strokeLinejoin\":\"round\",\"className\":\"lucide lucide-circle-check-big w-4 h-4 text-carefuse-teal mr-2 mt-1 flex-shrink-0\",\"aria-hidden\":\"true\",\"children\":[[\"$\",\"path\",\"yps3ct\",{\"d\":\"M21.801 10A10 10 0 1 1 17 3.335\"}],[\"$\",\"path\",\"1pflzl\",{\"d\":\"m9 11 3 3L22 4\"}],\"$undefined\"]}],\"Ensured FDA non-device CDS exemption compliance\"]}],[\"$\",\"li\",null,{\"className\":\"flex items-start\",\"children\":[[\"$\",\"svg\",null,{\"xmlns\":\"http://www.w3.org/2000/svg\",\"width\":24,\"height\":24,\"viewBox\":\"0 0 24 24\",\"fill\":\"none\",\"stroke\":\"currentColor\",\"strokeWidth\":2,\"strokeLinecap\":\"round\",\"strokeLinejoin\":\"round\",\"className\":\"lucide lucide-circle-check-big w-4 h-4 text-carefuse-teal mr-2 mt-1 flex-shrink-0\",\"aria-hidden\":\"true\",\"children\":[[\"$\",\"path\",\"yps3ct\",{\"d\":\"M21.801 10A10 10 0 1 1 17 3.335\"}],[\"$\",\"path\",\"1pflzl\",{\"d\":\"m9 11 3 3L22 4\"}],\"$undefined\"]}],\"Implemented multi-seed holdout validation\"]}]]}]]}]]}]}]]}]}],[\"$\",\"section\",null,{\"className\":\"mb-20\",\"children\":[\"$\",\"div\",null,{\"className\":\"rounded-lg border border-gray-200 shadow-sm hover:shadow-md hover:border-gray-300 transition-all duration-200 bg-gradient-to-br from-carefuse-navy to-carefuse-teal text-white\",\"children\":[\"$\",\"div\",null,{\"className\":\"p-8 text-center\",\"children\":[[\"$\",\"h2\",null,{\"className\":\"text-2xl font-bold mb-4\",\"children\":\"Impact \u0026 Vision\"}],[\"$\",\"p\",null,{\"className\":\"text-lg leading-relaxed mb-6\",\"children\":\"CareFuse represents my commitment to using AI for patient safety and clinical transparency. By providing explainable predictions and seamless workflow integration, we're helping healthcare providers make evidence-based decisions that prioritize patient outcomes over volume.\"}],[\"$\",\"div\",null,{\"className\":\"grid grid-cols-1 md:grid-cols-3 gap-6 text-center\",\"children\":[[\"$\",\"div\",null,{\"children\":[[\"$\",\"div\",null,{\"className\":\"text-3xl font-bold mb-2\",\"children\":\"38%\"}],[\"$\",\"div\",null,{\"className\":\"text-sm opacity-90\",\"children\":\"Avoidable TKAs with structured care\"}]]}],[\"$\",\"div\",null,{\"children\":[[\"$\",\"div\",null,{\"className\":\"text-3xl font-bold mb-2\",\"children\":\"~0.93\"}],[\"$\",\"div\",null,{\"className\":\"text-sm opacity-90\",\"children\":\"AUC for outcome prediction\"}]]}],[\"$\",\"div\",null,{\"children\":[[\"$\",\"div\",null,{\"className\":\"text-3xl font-bold mb-2\",\"children\":\"100%\"}],[\"$\",\"div\",null,{\"className\":\"text-sm opacity-90\",\"children\":\"Transparent, explainable decisions\"}]]}]]}]]}]}]}],[\"$\",\"div\",null,{\"className\":\"text-center\",\"children\":[\"$\",\"$L5\",null,{\"href\":\"/experience\",\"className\":\"inline-flex items-center bg-carefuse-teal text-white px-6 py-3 rounded-lg hover:bg-carefuse-teal/90 transition-colors font-medium\",\"children\":[\"Next: Experience\",[\"$\",\"svg\",null,{\"xmlns\":\"http://www.w3.org/2000/svg\",\"width\":24,\"height\":24,\"viewBox\":\"0 0 24 24\",\"fill\":\"none\",\"stroke\":\"currentColor\",\"strokeWidth\":2,\"strokeLinecap\":\"round\",\"strokeLinejoin\":\"round\",\"className\":\"lucide lucide-arrow-right w-4 h-4 ml-2\",\"aria-hidden\":\"true\",\"children\":[[\"$\",\"path\",\"1ays0h\",{\"d\":\"M5 12h14\"}],[\"$\",\"path\",\"xquz4c\",{\"d\":\"m12 5 7 7-7 7\"}],\"$undefined\"]}]]}]}]]}]}],null],null],null]},[null,[\"$\",\"$L6\",null,{\"parallelRouterKey\":\"children\",\"segmentPath\":[\"children\",\"carefuse\",\"children\"],\"error\":\"$undefined\",\"errorStyles\":\"$undefined\",\"errorScripts\":\"$undefined\",\"template\":[\"$\",\"$L7\",null,{}],\"templateStyles\":\"$undefined\",\"templateScripts\":\"$undefined\",\"notFound\":\"$undefined\",\"notFoundStyles\":\"$undefined\"}]],null]},[[[[\"$\",\"link\",\"0\",{\"rel\":\"stylesheet\",\"href\":\"/_next/static/css/28d069147ec3b886.css\",\"precedence\":\"next\",\"crossOrigin\":\"$undefined\"}]],[\"$\",\"html\",null,{\"lang\":\"en\",\"children\":[\"$\",\"body\",null,{\"className\":\"font-sans antialiased\",\"children\":[[\"$\",\"$L8\",null,{}],[\"$\",\"main\",null,{\"className\":\"min-h-screen\",\"children\":[\"$\",\"$L6\",null,{\"parallelRouterKey\":\"children\",\"segmentPath\":[\"children\"],\"error\":\"$undefined\",\"errorStyles\":\"$undefined\",\"errorScripts\":\"$undefined\",\"template\":[\"$\",\"$L7\",null,{}],\"templateStyles\":\"$undefined\",\"templateScripts\":\"$undefined\",\"notFound\":[[\"$\",\"title\",null,{\"children\":\"404: This page could not be found.\"}],[\"$\",\"div\",null,{\"style\":{\"fontFamily\":\"system-ui,\\\"Segoe UI\\\",Roboto,Helvetica,Arial,sans-serif,\\\"Apple Color Emoji\\\",\\\"Segoe UI Emoji\\\"\",\"height\":\"100vh\",\"textAlign\":\"center\",\"display\":\"flex\",\"flexDirection\":\"column\",\"alignItems\":\"center\",\"justifyContent\":\"center\"},\"children\":[\"$\",\"div\",null,{\"children\":[[\"$\",\"style\",null,{\"dangerouslySetInnerHTML\":{\"__html\":\"body{color:#000;background:#fff;margin:0}.next-error-h1{border-right:1px solid rgba(0,0,0,.3)}@media (prefers-color-scheme:dark){body{color:#fff;background:#000}.next-error-h1{border-right:1px solid rgba(255,255,255,.3)}}\"}}],[\"$\",\"h1\",null,{\"className\":\"next-error-h1\",\"style\":{\"display\":\"inline-block\",\"margin\":\"0 20px 0 0\",\"padding\":\"0 23px 0 0\",\"fontSize\":24,\"fontWeight\":500,\"verticalAlign\":\"top\",\"lineHeight\":\"49px\"},\"children\":\"404\"}],[\"$\",\"div\",null,{\"style\":{\"display\":\"inline-block\"},\"children\":[\"$\",\"h2\",null,{\"style\":{\"fontSize\":14,\"fontWeight\":400,\"lineHeight\":\"49px\",\"margin\":0},\"children\":\"This page could not be found.\"}]}]]}]}]],\"notFoundStyles\":[]}]}],[\"$\",\"footer\",null,{\"className\":\"bg-gray-900 text-white\",\"children\":[\"$\",\"div\",null,{\"className\":\"max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12\",\"children\":[[\"$\",\"div\",null,{\"className\":\"grid grid-cols-1 md:grid-cols-3 gap-8\",\"children\":[[\"$\",\"div\",null,{\"children\":[[\"$\",\"h3\",null,{\"className\":\"text-lg font-semibold mb-4\",\"children\":\"Contact\"}],[\"$\",\"div\",null,{\"className\":\"space-y-3\",\"children\":[[\"$\",\"div\",null,{\"className\":\"flex items-center space-x-3\",\"children\":[[\"$\",\"svg\",null,{\"xmlns\":\"http://www.w3.org/2000/svg\",\"width\":24,\"height\":24,\"viewBox\":\"0 0 24 24\",\"fill\":\"none\",\"stroke\":\"currentColor\",\"strokeWidth\":2,\"strokeLinecap\":\"round\",\"strokeLinejoin\":\"round\",\"className\":\"lucide lucide-mail w-5 h-5 text-gray-400\",\"aria-hidden\":\"true\",\"children\":[[\"$\",\"path\",\"132q7q\",{\"d\":\"m22 7-8.991 5.727a2 2 0 0 1-2.009 0L2 7\"}],[\"$\",\"rect\",\"izxlao\",{\"x\":\"2\",\"y\":\"4\",\"width\":\"20\",\"height\":\"16\",\"rx\":\"2\"}],\"$undefined\"]}],[\"$\",\"a\",null,{\"href\":\"mailto:yuri.braga@carefuseai.com\",\"className\":\"hover:text-carefuse-teal transition-colors\",\"children\":\"yuri.braga@carefuseai.com\"}]]}],[\"$\",\"div\",null,{\"className\":\"flex items-center space-x-3\",\"children\":[[\"$\",\"svg\",null,{\"xmlns\":\"http://www.w3.org/2000/svg\",\"width\":24,\"height\":24,\"viewBox\":\"0 0 24 24\",\"fill\":\"none\",\"stroke\":\"currentColor\",\"strokeWidth\":2,\"strokeLinecap\":\"round\",\"strokeLinejoin\":\"round\",\"className\":\"lucide lucide-phone w-5 h-5 text-gray-400\",\"aria-hidden\":\"true\",\"children\":[[\"$\",\"path\",\"9njp5v\",{\"d\":\"M13.832 16.568a1 1 0 0 0 1.213-.303l.355-.465A2 2 0 0 1 17 15h3a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2A18 18 0 0 1 2 4a2 2 0 0 1 2-2h3a2 2 0 0 1 2 2v3a2 2 0 0 1-.8 1.6l-.468.351a1 1 0 0 0-.292 1.233 14 14 0 0 0 6.392 6.384\"}],\"$undefined\"]}],[\"$\",\"a\",null,{\"href\":\"tel:+15409984267\",\"className\":\"hover:text-carefuse-teal transition-colors\",\"children\":\"+1 (540) 998-4267\"}]]}]]}]]}],[\"$\",\"div\",null,{\"children\":[[\"$\",\"h3\",null,{\"className\":\"text-lg font-semibold mb-4\",\"children\":\"Quick Links\"}],[\"$\",\"div\",null,{\"className\":\"space-y-2\",\"children\":[[\"$\",\"$L5\",null,{\"href\":\"/about\",\"className\":\"block hover:text-carefuse-teal transition-colors\",\"children\":\"About\"}],[\"$\",\"$L5\",null,{\"href\":\"/carefuse\",\"className\":\"block hover:text-carefuse-teal transition-colors\",\"children\":\"CareFuse\"}],[\"$\",\"$L5\",null,{\"href\":\"/academics\",\"className\":\"block hover:text-carefuse-teal transition-colors\",\"children\":\"Academics\"}],[\"$\",\"$L5\",null,{\"href\":\"/contact\",\"className\":\"block hover:text-carefuse-teal transition-colors\",\"children\":\"Contact\"}],[\"$\",\"$L5\",null,{\"href\":\"/resume\",\"className\":\"block hover:text-carefuse-teal transition-colors\",\"children\":\"Resume\"}]]}]]}],[\"$\",\"div\",null,{\"children\":[[\"$\",\"h3\",null,{\"className\":\"text-lg font-semibold mb-4\",\"children\":\"Connect\"}],[\"$\",\"div\",null,{\"className\":\"space-y-2\",\"children\":[[\"$\",\"a\",null,{\"href\":\"https://www.linkedin.com/in/yuribraga1/\",\"target\":\"_blank\",\"rel\":\"noopener noreferrer\",\"className\":\"flex items-center space-x-2 text-gray-400 hover:text-carefuse-teal transition-colors\",\"children\":[[\"$\",\"svg\",null,{\"xmlns\":\"http://www.w3.org/2000/svg\",\"width\":24,\"height\":24,\"viewBox\":\"0 0 24 24\",\"fill\":\"none\",\"stroke\":\"currentColor\",\"strokeWidth\":2,\"strokeLinecap\":\"round\",\"strokeLinejoin\":\"round\",\"className\":\"lucide lucide-linkedin w-5 h-5\",\"aria-hidden\":\"true\",\"children\":[[\"$\",\"path\",\"c2jq9f\",{\"d\":\"M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z\"}],[\"$\",\"rect\",\"mk3on5\",{\"width\":\"4\",\"height\":\"12\",\"x\":\"2\",\"y\":\"9\"}],[\"$\",\"circle\",\"bt5ra8\",{\"cx\":\"4\",\"cy\":\"4\",\"r\":\"2\"}],\"$undefined\"]}],[\"$\",\"span\",null,{\"children\":\"LinkedIn\"}]]}],[\"$\",\"a\",null,{\"href\":\"https://carefuseai.com\",\"target\":\"_blank\",\"rel\":\"noopener noreferrer\",\"className\":\"block text-gray-400 hover:text-vt-orange transition-colors\",\"children\":\"CareFuse Website\"}]]}]]}]]}],[\"$\",\"div\",null,{\"className\":\"border-t border-gray-800 mt-8 pt-8 text-center\",\"children\":[\"$\",\"p\",null,{\"className\":\"text-gray-400 text-sm\",\"children\":[\"© 2024 Yuri Braga. All rights reserved. •\",[\"$\",\"span\",null,{\"className\":\"ml-1\",\"children\":\"Built with Next.js and Tailwind CSS\"}]]}]}]]}]}]]}]}]],null],null],\"couldBeIntercepted\":false,\"initialHead\":[null,\"$L9\"],\"globalErrorComponent\":\"$a\",\"missingSlots\":\"$Wb\"}]\n"])</script>
+<script>self.__next_f.push([1,"9:[[\"$\",\"meta\",\"0\",{\"name\":\"viewport\",\"content\":\"width=device-width, initial-scale=1\"}],[\"$\",\"meta\",\"1\",{\"charSet\":\"utf-8\"}],[\"$\",\"title\",\"2\",{\"children\":\"Yuri Braga - Computer Engineer \u0026 Healthcare AI Researcher\"}],[\"$\",\"meta\",\"3\",{\"name\":\"description\",\"content\":\"Computer Engineer at Virginia Tech specializing in healthcare AI, machine learning for patient safety, and explainable AI models for clinical decision support.\"}],[\"$\",\"meta\",\"4\",{\"name\":\"author\",\"content\":\"Yuri Braga\"}],[\"$\",\"meta\",\"5\",{\"name\":\"keywords\",\"content\":\"machine learning, healthcare AI, explainable AI, surgical outcomes, Total Knee Arthroplasty, MCID, patient safety, Virginia Tech, computer engineering\"}],[\"$\",\"meta\",\"6\",{\"property\":\"og:title\",\"content\":\"Yuri Braga - Computer Engineer \u0026 Healthcare AI Researcher\"}],[\"$\",\"meta\",\"7\",{\"property\":\"og:description\",\"content\":\"Computer Engineer at Virginia Tech specializing in healthcare AI, machine learning for patient safety, and explainable AI models for clinical decision support.\"}],[\"$\",\"meta\",\"8\",{\"property\":\"og:url\",\"content\":\"https://yuribraga.dev/\"}],[\"$\",\"meta\",\"9\",{\"property\":\"og:site_name\",\"content\":\"Yuri Braga Portfolio\"}],[\"$\",\"meta\",\"10\",{\"property\":\"og:type\",\"content\":\"website\"}],[\"$\",\"meta\",\"11\",{\"name\":\"twitter:card\",\"content\":\"summary_large_image\"}],[\"$\",\"meta\",\"12\",{\"name\":\"twitter:title\",\"content\":\"Yuri Braga - Computer Engineer \u0026 Healthcare AI Researcher\"}],[\"$\",\"meta\",\"13\",{\"name\":\"twitter:description\",\"content\":\"Computer Engineer at Virginia Tech specializing in healthcare AI and patient safety.\"}],[\"$\",\"link\",\"14\",{\"rel\":\"icon\",\"href\":\"/favicon.ico\",\"type\":\"image/x-icon\",\"sizes\":\"16x16\"}]]\n3:null\n"])</script>
+</body>
+</html>
 

--- a/carefuse/index.txt
+++ b/carefuse/index.txt
@@ -1,8 +1,662 @@
-2:I[5878,["972","static/chunks/972-e6acae3a74adc8b1.js","878","static/chunks/878-a2053ba011a8f515.js","346","static/chunks/app/carefuse/page-af51f567578b7af3.js"],"Image"]
-3:I[2972,["972","static/chunks/972-e6acae3a74adc8b1.js","878","static/chunks/878-a2053ba011a8f515.js","346","static/chunks/app/carefuse/page-af51f567578b7af3.js"],""]
-4:I[4707,[],""]
-5:I[6423,[],""]
-6:I[3064,["972","static/chunks/972-e6acae3a74adc8b1.js","878","static/chunks/878-a2053ba011a8f515.js","185","static/chunks/app/layout-96060b751e953699.js"],"default"]
-0:["TvnfXHU6nbvB6OIZi7NfN",[[["",{"children":["carefuse",{"children":["__PAGE__",{}]}]},"$undefined","$undefined",true],["",{"children":["carefuse",{"children":["__PAGE__",{},[["$L1",["$","div",null,{"className":"py-20 bg-white","children":["$","div",null,{"className":"max-w-7xl mx-auto px-4 sm:px-6 lg:px-8","children":[["$","div",null,{"className":"text-center mb-16","children":[["$","div",null,{"className":"flex justify-center mb-6","children":["$","$L2",null,{"src":"/images/carefuse_logo.png","alt":"CareFuse","width":80,"height":80,"className":"w-20 h-20"}]}],["$","h1",null,{"className":"text-4xl sm:text-5xl font-bold text-carefuse-navy mb-6","children":"CareFuse"}],["$","p",null,{"className":"text-xl text-carefuse-gray max-w-3xl mx-auto mb-8","children":"Transparent AI for Hip & Knee Prior Authorization. Per-member clinical predictions with SHAP explanations, built for InterQual/MCG workflows and HL7 FHIR PAS."}],["$","a",null,{"href":"https://carefuseai.com","target":"_blank","rel":"noopener noreferrer","className":"inline-flex items-center bg-carefuse-teal text-white px-6 py-3 rounded-lg hover:bg-carefuse-teal/90 transition-colors font-medium","children":[["$","svg",null,{"xmlns":"http://www.w3.org/2000/svg","width":24,"height":24,"viewBox":"0 0 24 24","fill":"none","stroke":"currentColor","strokeWidth":2,"strokeLinecap":"round","strokeLinejoin":"round","className":"lucide lucide-external-link w-4 h-4 mr-2","aria-hidden":"true","children":[["$","path","1q9fwt",{"d":"M15 3h6v6"}],["$","path","gplh6r",{"d":"M10 14 21 3"}],["$","path","a6xqqp",{"d":"M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"}],"$undefined"]}],"Visit CareFuse Website"]}]]}],["$","section",null,{"className":"mb-20","children":[["$","div",null,{"className":"text-center mb-12","children":[["$","h2",null,{"className":"text-3xl font-bold text-carefuse-navy mb-4","children":"The Perfect Storm: Four Converging Healthcare Forces"}],["$","p",null,{"className":"text-lg text-carefuse-gray max-w-4xl mx-auto","children":"The U.S. healthcare system is experiencing unprecedented regulatory convergence that's transforming how knee replacement decisions are made, measured, and governed."}]]}],["$","div",null,{"className":"grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6","children":[["$","div",null,{"className":"bg-white rounded-lg border shadow-sm hover:shadow-md duration-200 text-center border-carefuse-teal/20 hover:border-carefuse-teal/50 transition-colors","children":[["$","div",null,{"className":"p-6 pb-4","children":[["$","div",null,{"className":"w-16 h-16 bg-carefuse-teal/10 rounded-full flex items-center justify-center mx-auto mb-4","children":["$","svg",null,{"xmlns":"http://www.w3.org/2000/svg","width":24,"height":24,"viewBox":"0 0 24 24","fill":"none","stroke":"currentColor","strokeWidth":2,"strokeLinecap":"round","strokeLinejoin":"round","className":"lucide lucide-chart-column w-8 h-8 text-carefuse-teal","aria-hidden":"true","children":[["$","path","c24i48",{"d":"M3 3v16a2 2 0 0 0 2 2h16"}],["$","path","2bz60n",{"d":"M18 17V9"}],["$","path","1frdt8",{"d":"M13 17V5"}],["$","path","17ska0",{"d":"M8 17v-3"}],"$undefined"]}]}],["$","h3",null,{"className":"font-semibold mb-2 text-carefuse-navy text-lg","children":"The Accountability Challenge"}]]}],["$","div",null,{"className":"px-6 pb-6","children":[["$","div",null,{"className":"text-3xl font-bold text-carefuse-teal mb-2","children":"24%"}],["$","p",null,{"className":"text-sm text-carefuse-gray","children":"APU Reduction Penalty for non-compliance with PROMs collection"}]]}]]}],["$","div",null,{"className":"bg-white rounded-lg border shadow-sm hover:shadow-md duration-200 text-center border-carefuse-teal/20 hover:border-carefuse-teal/50 transition-colors","children":[["$","div",null,{"className":"p-6 pb-4","children":[["$","div",null,{"className":"w-16 h-16 bg-carefuse-teal/10 rounded-full flex items-center justify-center mx-auto mb-4","children":["$","svg",null,{"xmlns":"http://www.w3.org/2000/svg","width":24,"height":24,"viewBox":"0 0 24 24","fill":"none","stroke":"currentColor","strokeWidth":2,"strokeLinecap":"round","strokeLinejoin":"round","className":"lucide lucide-users w-8 h-8 text-carefuse-teal","aria-hidden":"true","children":[["$","path","1yyitq",{"d":"M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2"}],["$","path","16gr8j",{"d":"M16 3.128a4 4 0 0 1 0 7.744"}],["$","path","kshegd",{"d":"M22 21v-2a4 4 0 0 0-3-3.87"}],["$","circle","nufk8",{"cx":"9","cy":"7","r":"4"}],"$undefined"]}]}],["$","h3",null,{"className":"font-semibold mb-2 text-carefuse-navy text-lg","children":"The Subjectivity Problem"}]]}],["$","div",null,{"className":"px-6 pb-6","children":[["$","div",null,{"className":"text-3xl font-bold text-carefuse-teal mb-2","children":"High"}],["$","p",null,{"className":"text-sm text-carefuse-gray","children":"Physician Variation - Significant disagreement on TKA indications"}]]}]]}],["$","div",null,{"className":"bg-white rounded-lg border shadow-sm hover:shadow-md duration-200 text-center border-carefuse-teal/20 hover:border-carefuse-teal/50 transition-colors","children":[["$","div",null,{"className":"p-6 pb-4","children":[["$","div",null,{"className":"w-16 h-16 bg-carefuse-teal/10 rounded-full flex items-center justify-center mx-auto mb-4","children":["$","svg",null,{"xmlns":"http://www.w3.org/2000/svg","width":24,"height":24,"viewBox":"0 0 24 24","fill":"none","stroke":"currentColor","strokeWidth":2,"strokeLinecap":"round","strokeLinejoin":"round","className":"lucide lucide-shield w-8 h-8 text-carefuse-teal","aria-hidden":"true","children":[["$","path","oel41y",{"d":"M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z"}],"$undefined"]}]}],["$","h3",null,{"className":"font-semibold mb-2 text-carefuse-navy text-lg","children":"The Transparency Requirement"}]]}],["$","div",null,{"className":"px-6 pb-6","children":[["$","div",null,{"className":"text-3xl font-bold text-carefuse-teal mb-2","children":"6"}],["$","p",null,{"className":"text-sm text-carefuse-gray","children":"States with AI Laws requiring physician oversight of AI decisions"}]]}]]}],["$","div",null,{"className":"bg-white rounded-lg border shadow-sm hover:shadow-md duration-200 text-center border-carefuse-teal/20 hover:border-carefuse-teal/50 transition-colors","children":[["$","div",null,{"className":"p-6 pb-4","children":[["$","div",null,{"className":"w-16 h-16 bg-carefuse-teal/10 rounded-full flex items-center justify-center mx-auto mb-4","children":["$","svg",null,{"xmlns":"http://www.w3.org/2000/svg","width":24,"height":24,"viewBox":"0 0 24 24","fill":"none","stroke":"currentColor","strokeWidth":2,"strokeLinecap":"round","strokeLinejoin":"round","className":"lucide lucide-trending-up w-8 h-8 text-carefuse-teal","aria-hidden":"true","children":[["$","path","box55l",{"d":"M16 7h6v6"}],["$","path","1t1m79",{"d":"m22 7-8.5 8.5-5-5L2 17"}],"$undefined"]}]}],["$","h3",null,{"className":"font-semibold mb-2 text-carefuse-navy text-lg","children":"The Evidence Gap Problem"}]]}],["$","div",null,{"className":"px-6 pb-6","children":[["$","div",null,{"className":"text-3xl font-bold text-carefuse-teal mb-2","children":"38%"}],["$","p",null,{"className":"text-sm text-carefuse-gray","children":"TKAs Avoidable with structured conservative care"}]]}]]}]]}]]}],["$","section",null,{"className":"mb-20","children":[["$","div",null,{"className":"text-center mb-12","children":[["$","h2",null,{"className":"text-3xl font-bold text-carefuse-navy mb-4","children":"CareFuse Solution"}],["$","p",null,{"className":"text-lg text-carefuse-gray max-w-4xl mx-auto","children":"Our platform addresses these challenges with transparent, explainable AI that integrates seamlessly with existing healthcare workflows while ensuring regulatory compliance."}]]}],["$","div",null,{"className":"grid grid-cols-1 md:grid-cols-2 gap-8","children":[["$","div",null,{"className":"bg-white rounded-lg border shadow-sm hover:shadow-md duration-200 border-carefuse-teal/20 hover:border-carefuse-teal/50 transition-colors","children":[["$","div",null,{"className":"p-6 pb-4","children":["$","div",null,{"className":"flex items-center space-x-4","children":[["$","div",null,{"className":"w-12 h-12 bg-carefuse-teal/10 rounded-lg flex items-center justify-center","children":["$","svg",null,{"xmlns":"http://www.w3.org/2000/svg","width":24,"height":24,"viewBox":"0 0 24 24","fill":"none","stroke":"currentColor","strokeWidth":2,"strokeLinecap":"round","strokeLinejoin":"round","className":"lucide lucide-database w-6 h-6 text-carefuse-teal","aria-hidden":"true","children":[["$","ellipse","msslwz",{"cx":"12","cy":"5","rx":"9","ry":"3"}],["$","path","1wlel7",{"d":"M3 5V19A9 3 0 0 0 21 19V5"}],["$","path","mv7ke4",{"d":"M3 12A9 3 0 0 0 21 12"}],"$undefined"]}]}],["$","h3",null,{"className":"text-xl font-semibold mb-2 text-carefuse-navy","children":"FHIR PAS Ready"}]]}]}],["$","div",null,{"className":"px-6 pb-6","children":["$","p",null,{"className":"text-carefuse-gray","children":"Built for Da Vinci PAS workflows and ePA compliance by 2027"}]}]]}],["$","div",null,{"className":"bg-white rounded-lg border shadow-sm hover:shadow-md duration-200 border-carefuse-teal/20 hover:border-carefuse-teal/50 transition-colors","children":[["$","div",null,{"className":"p-6 pb-4","children":["$","div",null,{"className":"flex items-center space-x-4","children":[["$","div",null,{"className":"w-12 h-12 bg-carefuse-teal/10 rounded-lg flex items-center justify-center","children":["$","svg",null,{"xmlns":"http://www.w3.org/2000/svg","width":24,"height":24,"viewBox":"0 0 24 24","fill":"none","stroke":"currentColor","strokeWidth":2,"strokeLinecap":"round","strokeLinejoin":"round","className":"lucide lucide-brain w-6 h-6 text-carefuse-teal","aria-hidden":"true","children":[["$","path","adv99a",{"d":"M12 18V5"}],["$","path","1e3is1",{"d":"M15 13a4.17 4.17 0 0 1-3-4 4.17 4.17 0 0 1-3 4"}],["$","path","1gqd8o",{"d":"M17.598 6.5A3 3 0 1 0 12 5a3 3 0 1 0-5.598 1.5"}],["$","path","iwvgf7",{"d":"M17.997 5.125a4 4 0 0 1 2.526 5.77"}],["$","path","efp6ie",{"d":"M18 18a4 4 0 0 0 2-7.464"}],["$","path","1gq6am",{"d":"M19.967 17.483A4 4 0 1 1 12 18a4 4 0 1 1-7.967-.517"}],["$","path","k1g0md",{"d":"M6 18a4 4 0 0 1-2-7.464"}],["$","path","q97ue3",{"d":"M6.003 5.125a4 4 0 0 0-2.526 5.77"}],"$undefined"]}]}],["$","h3",null,{"className":"text-xl font-semibold mb-2 text-carefuse-navy","children":"SHAP Explainable"}]]}]}],["$","div",null,{"className":"px-6 pb-6","children":["$","p",null,{"className":"text-carefuse-gray","children":"Transparent AI with per-member clinical explanations"}]}]]}],["$","div",null,{"className":"bg-white rounded-lg border shadow-sm hover:shadow-md duration-200 border-carefuse-teal/20 hover:border-carefuse-teal/50 transition-colors","children":[["$","div",null,{"className":"p-6 pb-4","children":["$","div",null,{"className":"flex items-center space-x-4","children":[["$","div",null,{"className":"w-12 h-12 bg-carefuse-teal/10 rounded-lg flex items-center justify-center","children":["$","svg",null,{"xmlns":"http://www.w3.org/2000/svg","width":24,"height":24,"viewBox":"0 0 24 24","fill":"none","stroke":"currentColor","strokeWidth":2,"strokeLinecap":"round","strokeLinejoin":"round","className":"lucide lucide-circle-check-big w-6 h-6 text-carefuse-teal","aria-hidden":"true","children":[["$","path","yps3ct",{"d":"M21.801 10A10 10 0 1 1 17 3.335"}],["$","path","1pflzl",{"d":"m9 11 3 3L22 4"}],"$undefined"]}]}],["$","h3",null,{"className":"text-xl font-semibold mb-2 text-carefuse-navy","children":"InterQual/MCG Compatible"}]]}]}],["$","div",null,{"className":"px-6 pb-6","children":["$","p",null,{"className":"text-carefuse-gray","children":"Seamless integration with existing UM workflows"}]}]]}],["$","div",null,{"className":"bg-white rounded-lg border shadow-sm hover:shadow-md duration-200 border-carefuse-teal/20 hover:border-carefuse-teal/50 transition-colors","children":[["$","div",null,{"className":"p-6 pb-4","children":["$","div",null,{"className":"flex items-center space-x-4","children":[["$","div",null,{"className":"w-12 h-12 bg-carefuse-teal/10 rounded-lg flex items-center justify-center","children":["$","svg",null,{"xmlns":"http://www.w3.org/2000/svg","width":24,"height":24,"viewBox":"0 0 24 24","fill":"none","stroke":"currentColor","strokeWidth":2,"strokeLinecap":"round","strokeLinejoin":"round","className":"lucide lucide-stethoscope w-6 h-6 text-carefuse-teal","aria-hidden":"true","children":[["$","path","1539x4",{"d":"M11 2v2"}],["$","path","1yf1q8",{"d":"M5 2v2"}],["$","path","rb5t3r",{"d":"M5 3H4a2 2 0 0 0-2 2v4a6 6 0 0 0 12 0V5a2 2 0 0 0-2-2h-1"}],["$","path","x18d4x",{"d":"M8 15a6 6 0 0 0 12 0v-3"}],["$","circle","ts1r5v",{"cx":"20","cy":"10","r":"2"}],"$undefined"]}]}],["$","h3",null,{"className":"text-xl font-semibold mb-2 text-carefuse-navy","children":"FDA Compliant"}]]}]}],["$","div",null,{"className":"px-6 pb-6","children":["$","p",null,{"className":"text-carefuse-gray","children":"Built under FDA non-device CDS exemption for healthcare compliance"}]}]]}]]}]]}],["$","section",null,{"className":"mb-20","children":["$","div",null,{"className":"rounded-lg border shadow-sm hover:shadow-md hover:border-gray-300 transition-all duration-200 bg-carefuse-light border-carefuse-teal/20","children":[["$","div",null,{"className":"p-6 pb-4 text-center","children":[["$","h3",null,{"className":"font-semibold mb-2 text-carefuse-navy text-2xl","children":"My Role & Technical Contributions"}],["$","p",null,{"className":"leading-relaxed text-carefuse-gray","children":"Co-founder & Machine Learning Lead at CareFuse"}]]}],["$","div",null,{"className":"px-6 pb-6 space-y-6","children":["$","div",null,{"className":"grid grid-cols-1 md:grid-cols-2 gap-8","children":[["$","div",null,{"children":[["$","h3",null,{"className":"text-lg font-semibold text-carefuse-navy mb-3","children":"Machine Learning Development"}],["$","ul",null,{"className":"space-y-2 text-carefuse-gray","children":[["$","li",null,{"className":"flex items-start","children":[["$","svg",null,{"xmlns":"http://www.w3.org/2000/svg","width":24,"height":24,"viewBox":"0 0 24 24","fill":"none","stroke":"currentColor","strokeWidth":2,"strokeLinecap":"round","strokeLinejoin":"round","className":"lucide lucide-circle-check-big w-4 h-4 text-carefuse-teal mr-2 mt-1 flex-shrink-0","aria-hidden":"true","children":[["$","path","yps3ct",{"d":"M21.801 10A10 10 0 1 1 17 3.335"}],["$","path","1pflzl",{"d":"m9 11 3 3L22 4"}],"$undefined"]}],"Developed explainable AI models for TKA outcome prediction"]}],["$","li",null,{"className":"flex items-start","children":[["$","svg",null,{"xmlns":"http://www.w3.org/2000/svg","width":24,"height":24,"viewBox":"0 0 24 24","fill":"none","stroke":"currentColor","strokeWidth":2,"strokeLinecap":"round","strokeLinejoin":"round","className":"lucide lucide-circle-check-big w-4 h-4 text-carefuse-teal mr-2 mt-1 flex-shrink-0","aria-hidden":"true","children":[["$","path","yps3ct",{"d":"M21.801 10A10 10 0 1 1 17 3.335"}],["$","path","1pflzl",{"d":"m9 11 3 3L22 4"}],"$undefined"]}],"Implemented SHAP explanations for clinical transparency"]}],["$","li",null,{"className":"flex items-start","children":[["$","svg",null,{"xmlns":"http://www.w3.org/2000/svg","width":24,"height":24,"viewBox":"0 0 24 24","fill":"none","stroke":"currentColor","strokeWidth":2,"strokeLinecap":"round","strokeLinejoin":"round","className":"lucide lucide-circle-check-big w-4 h-4 text-carefuse-teal mr-2 mt-1 flex-shrink-0","aria-hidden":"true","children":[["$","path","yps3ct",{"d":"M21.801 10A10 10 0 1 1 17 3.335"}],["$","path","1pflzl",{"d":"m9 11 3 3L22 4"}],"$undefined"]}],"Achieved ~0.93 AUC with robust calibration techniques"]}],["$","li",null,{"className":"flex items-start","children":[["$","svg",null,{"xmlns":"http://www.w3.org/2000/svg","width":24,"height":24,"viewBox":"0 0 24 24","fill":"none","stroke":"currentColor","strokeWidth":2,"strokeLinecap":"round","strokeLinejoin":"round","className":"lucide lucide-circle-check-big w-4 h-4 text-carefuse-teal mr-2 mt-1 flex-shrink-0","aria-hidden":"true","children":[["$","path","yps3ct",{"d":"M21.801 10A10 10 0 1 1 17 3.335"}],["$","path","1pflzl",{"d":"m9 11 3 3L22 4"}],"$undefined"]}],"Applied propensity weighting for causal robustness"]}]]}]]}],["$","div",null,{"children":[["$","h3",null,{"className":"text-lg font-semibold text-carefuse-navy mb-3","children":"Platform & Deployment"}],["$","ul",null,{"className":"space-y-2 text-carefuse-gray","children":[["$","li",null,{"className":"flex items-start","children":[["$","svg",null,{"xmlns":"http://www.w3.org/2000/svg","width":24,"height":24,"viewBox":"0 0 24 24","fill":"none","stroke":"currentColor","strokeWidth":2,"strokeLinecap":"round","strokeLinejoin":"round","className":"lucide lucide-circle-check-big w-4 h-4 text-carefuse-teal mr-2 mt-1 flex-shrink-0","aria-hidden":"true","children":[["$","path","yps3ct",{"d":"M21.801 10A10 10 0 1 1 17 3.335"}],["$","path","1pflzl",{"d":"m9 11 3 3L22 4"}],"$undefined"]}],"Built FastAPI + Docker deployment infrastructure"]}],["$","li",null,{"className":"flex items-start","children":[["$","svg",null,{"xmlns":"http://www.w3.org/2000/svg","width":24,"height":24,"viewBox":"0 0 24 24","fill":"none","stroke":"currentColor","strokeWidth":2,"strokeLinecap":"round","strokeLinejoin":"round","className":"lucide lucide-circle-check-big w-4 h-4 text-carefuse-teal mr-2 mt-1 flex-shrink-0","aria-hidden":"true","children":[["$","path","yps3ct",{"d":"M21.801 10A10 10 0 1 1 17 3.335"}],["$","path","1pflzl",{"d":"m9 11 3 3L22 4"}],"$undefined"]}],"Designed FHIR R4 and Da Vinci PAS integration"]}],["$","li",null,{"className":"flex items-start","children":[["$","svg",null,{"xmlns":"http://www.w3.org/2000/svg","width":24,"height":24,"viewBox":"0 0 24 24","fill":"none","stroke":"currentColor","strokeWidth":2,"strokeLinecap":"round","strokeLinejoin":"round","className":"lucide lucide-circle-check-big w-4 h-4 text-carefuse-teal mr-2 mt-1 flex-shrink-0","aria-hidden":"true","children":[["$","path","yps3ct",{"d":"M21.801 10A10 10 0 1 1 17 3.335"}],["$","path","1pflzl",{"d":"m9 11 3 3L22 4"}],"$undefined"]}],"Ensured FDA non-device CDS exemption compliance"]}],["$","li",null,{"className":"flex items-start","children":[["$","svg",null,{"xmlns":"http://www.w3.org/2000/svg","width":24,"height":24,"viewBox":"0 0 24 24","fill":"none","stroke":"currentColor","strokeWidth":2,"strokeLinecap":"round","strokeLinejoin":"round","className":"lucide lucide-circle-check-big w-4 h-4 text-carefuse-teal mr-2 mt-1 flex-shrink-0","aria-hidden":"true","children":[["$","path","yps3ct",{"d":"M21.801 10A10 10 0 1 1 17 3.335"}],["$","path","1pflzl",{"d":"m9 11 3 3L22 4"}],"$undefined"]}],"Implemented multi-seed holdout validation"]}]]}]]}]]}]}]]}]}],["$","section",null,{"className":"mb-20","children":["$","div",null,{"className":"rounded-lg border border-gray-200 shadow-sm hover:shadow-md hover:border-gray-300 transition-all duration-200 bg-gradient-to-br from-carefuse-navy to-carefuse-teal text-white","children":["$","div",null,{"className":"p-8 text-center","children":[["$","h2",null,{"className":"text-2xl font-bold mb-4","children":"Impact & Vision"}],["$","p",null,{"className":"text-lg leading-relaxed mb-6","children":"CareFuse represents my commitment to using AI for patient safety and clinical transparency. By providing explainable predictions and seamless workflow integration, we're helping healthcare providers make evidence-based decisions that prioritize patient outcomes over volume."}],["$","div",null,{"className":"grid grid-cols-1 md:grid-cols-3 gap-6 text-center","children":[["$","div",null,{"children":[["$","div",null,{"className":"text-3xl font-bold mb-2","children":"38%"}],["$","div",null,{"className":"text-sm opacity-90","children":"Avoidable TKAs with structured care"}]]}],["$","div",null,{"children":[["$","div",null,{"className":"text-3xl font-bold mb-2","children":"~0.93"}],["$","div",null,{"className":"text-sm opacity-90","children":"AUC for outcome prediction"}]]}],["$","div",null,{"children":[["$","div",null,{"className":"text-3xl font-bold mb-2","children":"100%"}],["$","div",null,{"className":"text-sm opacity-90","children":"Transparent, explainable decisions"}]]}]]}]]}]}]}],["$","div",null,{"className":"text-center","children":["$","$L3",null,{"href":"/experience","className":"inline-flex items-center bg-carefuse-teal text-white px-6 py-3 rounded-lg hover:bg-carefuse-teal/90 transition-colors font-medium","children":["Next: Experience",["$","svg",null,{"xmlns":"http://www.w3.org/2000/svg","width":24,"height":24,"viewBox":"0 0 24 24","fill":"none","stroke":"currentColor","strokeWidth":2,"strokeLinecap":"round","strokeLinejoin":"round","className":"lucide lucide-arrow-right w-4 h-4 ml-2","aria-hidden":"true","children":[["$","path","1ays0h",{"d":"M5 12h14"}],["$","path","xquz4c",{"d":"m12 5 7 7-7 7"}],"$undefined"]}]]}]}]]}]}],null],null],null]},[null,["$","$L4",null,{"parallelRouterKey":"children","segmentPath":["children","carefuse","children"],"error":"$undefined","errorStyles":"$undefined","errorScripts":"$undefined","template":["$","$L5",null,{}],"templateStyles":"$undefined","templateScripts":"$undefined","notFound":"$undefined","notFoundStyles":"$undefined"}]],null]},[[[["$","link","0",{"rel":"stylesheet","href":"/_next/static/css/28d069147ec3b886.css","precedence":"next","crossOrigin":"$undefined"}]],["$","html",null,{"lang":"en","children":["$","body",null,{"className":"font-sans antialiased","children":[["$","$L6",null,{}],["$","main",null,{"className":"min-h-screen","children":["$","$L4",null,{"parallelRouterKey":"children","segmentPath":["children"],"error":"$undefined","errorStyles":"$undefined","errorScripts":"$undefined","template":["$","$L5",null,{}],"templateStyles":"$undefined","templateScripts":"$undefined","notFound":[["$","title",null,{"children":"404: This page could not be found."}],["$","div",null,{"style":{"fontFamily":"system-ui,\"Segoe UI\",Roboto,Helvetica,Arial,sans-serif,\"Apple Color Emoji\",\"Segoe UI Emoji\"","height":"100vh","textAlign":"center","display":"flex","flexDirection":"column","alignItems":"center","justifyContent":"center"},"children":["$","div",null,{"children":[["$","style",null,{"dangerouslySetInnerHTML":{"__html":"body{color:#000;background:#fff;margin:0}.next-error-h1{border-right:1px solid rgba(0,0,0,.3)}@media (prefers-color-scheme:dark){body{color:#fff;background:#000}.next-error-h1{border-right:1px solid rgba(255,255,255,.3)}}"}}],["$","h1",null,{"className":"next-error-h1","style":{"display":"inline-block","margin":"0 20px 0 0","padding":"0 23px 0 0","fontSize":24,"fontWeight":500,"verticalAlign":"top","lineHeight":"49px"},"children":"404"}],["$","div",null,{"style":{"display":"inline-block"},"children":["$","h2",null,{"style":{"fontSize":14,"fontWeight":400,"lineHeight":"49px","margin":0},"children":"This page could not be found."}]}]]}]}]],"notFoundStyles":[]}]}],["$","footer",null,{"className":"bg-gray-900 text-white","children":["$","div",null,{"className":"max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12","children":[["$","div",null,{"className":"grid grid-cols-1 md:grid-cols-3 gap-8","children":[["$","div",null,{"children":[["$","h3",null,{"className":"text-lg font-semibold mb-4","children":"Contact"}],["$","div",null,{"className":"space-y-3","children":[["$","div",null,{"className":"flex items-center space-x-3","children":[["$","svg",null,{"xmlns":"http://www.w3.org/2000/svg","width":24,"height":24,"viewBox":"0 0 24 24","fill":"none","stroke":"currentColor","strokeWidth":2,"strokeLinecap":"round","strokeLinejoin":"round","className":"lucide lucide-mail w-5 h-5 text-gray-400","aria-hidden":"true","children":[["$","path","132q7q",{"d":"m22 7-8.991 5.727a2 2 0 0 1-2.009 0L2 7"}],["$","rect","izxlao",{"x":"2","y":"4","width":"20","height":"16","rx":"2"}],"$undefined"]}],["$","a",null,{"href":"mailto:yuri.braga@carefuseai.com","className":"hover:text-carefuse-teal transition-colors","children":"yuri.braga@carefuseai.com"}]]}],["$","div",null,{"className":"flex items-center space-x-3","children":[["$","svg",null,{"xmlns":"http://www.w3.org/2000/svg","width":24,"height":24,"viewBox":"0 0 24 24","fill":"none","stroke":"currentColor","strokeWidth":2,"strokeLinecap":"round","strokeLinejoin":"round","className":"lucide lucide-phone w-5 h-5 text-gray-400","aria-hidden":"true","children":[["$","path","9njp5v",{"d":"M13.832 16.568a1 1 0 0 0 1.213-.303l.355-.465A2 2 0 0 1 17 15h3a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2A18 18 0 0 1 2 4a2 2 0 0 1 2-2h3a2 2 0 0 1 2 2v3a2 2 0 0 1-.8 1.6l-.468.351a1 1 0 0 0-.292 1.233 14 14 0 0 0 6.392 6.384"}],"$undefined"]}],["$","a",null,{"href":"tel:+15409984267","className":"hover:text-carefuse-teal transition-colors","children":"+1 (540) 998-4267"}]]}]]}]]}],["$","div",null,{"children":[["$","h3",null,{"className":"text-lg font-semibold mb-4","children":"Quick Links"}],["$","div",null,{"className":"space-y-2","children":[["$","$L3",null,{"href":"/about","className":"block hover:text-carefuse-teal transition-colors","children":"About"}],["$","$L3",null,{"href":"/carefuse","className":"block hover:text-carefuse-teal transition-colors","children":"CareFuse"}],["$","$L3",null,{"href":"/academics","className":"block hover:text-carefuse-teal transition-colors","children":"Academics"}],["$","$L3",null,{"href":"/contact","className":"block hover:text-carefuse-teal transition-colors","children":"Contact"}],["$","$L3",null,{"href":"/resume","className":"block hover:text-carefuse-teal transition-colors","children":"Resume"}]]}]]}],["$","div",null,{"children":[["$","h3",null,{"className":"text-lg font-semibold mb-4","children":"Connect"}],["$","div",null,{"className":"space-y-2","children":[["$","a",null,{"href":"https://www.linkedin.com/in/yuribraga1/","target":"_blank","rel":"noopener noreferrer","className":"flex items-center space-x-2 text-gray-400 hover:text-carefuse-teal transition-colors","children":[["$","svg",null,{"xmlns":"http://www.w3.org/2000/svg","width":24,"height":24,"viewBox":"0 0 24 24","fill":"none","stroke":"currentColor","strokeWidth":2,"strokeLinecap":"round","strokeLinejoin":"round","className":"lucide lucide-linkedin w-5 h-5","aria-hidden":"true","children":[["$","path","c2jq9f",{"d":"M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"}],["$","rect","mk3on5",{"width":"4","height":"12","x":"2","y":"9"}],["$","circle","bt5ra8",{"cx":"4","cy":"4","r":"2"}],"$undefined"]}],["$","span",null,{"children":"LinkedIn"}]]}],["$","a",null,{"href":"https://carefuseai.com","target":"_blank","rel":"noopener noreferrer","className":"block text-gray-400 hover:text-vt-orange transition-colors","children":"CareFuse Website"}]]}]]}]]}],["$","div",null,{"className":"border-t border-gray-800 mt-8 pt-8 text-center","children":["$","p",null,{"className":"text-gray-400 text-sm","children":["© 2024 Yuri Braga. All rights reserved. •",["$","span",null,{"className":"ml-1","children":"Built with Next.js and Tailwind CSS"}]]}]}]]}]}]]}]}]],null],null],["$L7",null]]]]
-7:[["$","meta","0",{"name":"viewport","content":"width=device-width, initial-scale=1"}],["$","meta","1",{"charSet":"utf-8"}],["$","title","2",{"children":"Yuri Braga - Computer Engineer & Healthcare AI Researcher"}],["$","meta","3",{"name":"description","content":"Computer Engineer at Virginia Tech specializing in healthcare AI, machine learning for patient safety, and explainable AI models for clinical decision support."}],["$","meta","4",{"name":"author","content":"Yuri Braga"}],["$","meta","5",{"name":"keywords","content":"machine learning, healthcare AI, explainable AI, surgical outcomes, Total Knee Arthroplasty, MCID, patient safety, Virginia Tech, computer engineering"}],["$","meta","6",{"property":"og:title","content":"Yuri Braga - Computer Engineer & Healthcare AI Researcher"}],["$","meta","7",{"property":"og:description","content":"Computer Engineer at Virginia Tech specializing in healthcare AI, machine learning for patient safety, and explainable AI models for clinical decision support."}],["$","meta","8",{"property":"og:url","content":"https://yuribraga.dev/"}],["$","meta","9",{"property":"og:site_name","content":"Yuri Braga Portfolio"}],["$","meta","10",{"property":"og:type","content":"website"}],["$","meta","11",{"name":"twitter:card","content":"summary_large_image"}],["$","meta","12",{"name":"twitter:title","content":"Yuri Braga - Computer Engineer & Healthcare AI Researcher"}],["$","meta","13",{"name":"twitter:description","content":"Computer Engineer at Virginia Tech specializing in healthcare AI and patient safety."}],["$","link","14",{"rel":"icon","href":"/favicon.ico","type":"image/x-icon","sizes":"16x16"}]]
-1:null
+<!DOCTYPE html>
+<html lang="en">
+ <head>
+  <meta charset="utf-8"/>
+  <meta content="width=device-width, initial-scale=1" name="viewport"/>
+  <link data-precedence="next" href="/_next/static/css/28d069147ec3b886.css" rel="stylesheet"/>
+  <link as="script" fetchpriority="low" href="/_next/static/chunks/webpack-616e068a201ad621.js" rel="preload"/>
+  <script async="" src="/_next/static/chunks/fd9d1056-357a9aa7cf7b0906.js">
+  </script>
+  <script async="" src="/_next/static/chunks/117-5f9b74e563f2720e.js">
+  </script>
+  <script async="" src="/_next/static/chunks/main-app-ff95fd5ca27d98e6.js">
+  </script>
+  <script async="" src="/_next/static/chunks/972-e6acae3a74adc8b1.js">
+  </script>
+  <script async="" src="/_next/static/chunks/878-a2053ba011a8f515.js">
+  </script>
+  <script async="" src="/_next/static/chunks/app/carefuse/page-af51f567578b7af3.js">
+  </script>
+  <script async="" src="/_next/static/chunks/app/layout-96060b751e953699.js">
+  </script>
+  <title>
+   Yuri Braga - Computer Engineer &amp; Healthcare AI Researcher
+  </title>
+  <meta content="Computer Engineer at Virginia Tech specializing in healthcare AI, machine learning for patient safety, and explainable AI models for clinical decision support." name="description"/>
+  <meta content="Yuri Braga" name="author"/>
+  <meta content="machine learning, healthcare AI, explainable AI, surgical outcomes, Total Knee Arthroplasty, MCID, patient safety, Virginia Tech, computer engineering" name="keywords"/>
+  <meta content="Yuri Braga - Computer Engineer &amp; Healthcare AI Researcher" property="og:title"/>
+  <meta content="Computer Engineer at Virginia Tech specializing in healthcare AI, machine learning for patient safety, and explainable AI models for clinical decision support." property="og:description"/>
+  <meta content="https://yuribraga.dev/" property="og:url"/>
+  <meta content="Yuri Braga Portfolio" property="og:site_name"/>
+  <meta content="website" property="og:type"/>
+  <meta content="summary_large_image" name="twitter:card"/>
+  <meta content="Yuri Braga - Computer Engineer &amp; Healthcare AI Researcher" name="twitter:title"/>
+  <meta content="Computer Engineer at Virginia Tech specializing in healthcare AI and patient safety." name="twitter:description"/>
+  <link href="/favicon.ico" rel="icon" sizes="16x16" type="image/x-icon"/>
+  <script nomodule="" src="/_next/static/chunks/polyfills-42372ed130431b0a.js">
+  </script>
+ </head>
+ <body class="font-sans antialiased">
+  <nav class="bg-white/95 backdrop-blur-sm border-b border-gray-200 sticky top-0 z-50">
+   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+    <div class="flex items-center justify-between h-16">
+     <div class="flex items-center">
+      <a class="flex items-center space-x-3" href="/">
+       <img alt="CareFuse" class="w-8 h-8" data-nimg="1" decoding="async" height="32" loading="lazy" src="/images/carefuse_logo.png" style="color:transparent" width="32"/>
+       <span class="text-xl font-bold text-gray-900">
+        Yuri Braga
+       </span>
+      </a>
+     </div>
+     <div class="hidden md:flex items-center space-x-8">
+      <a class="text-gray-700 hover:text-carefuse-teal transition-colors duration-200 text-sm font-medium" href="/">
+       Home
+      </a>
+      <a class="text-gray-700 hover:text-carefuse-teal transition-colors duration-200 text-sm font-medium" href="/about/">
+       About
+      </a>
+      <a class="text-gray-700 hover:text-carefuse-teal transition-colors duration-200 text-sm font-medium" href="/carefuse/">
+       CareFuse
+      </a>
+      <a class="text-gray-700 hover:text-carefuse-teal transition-colors duration-200 text-sm font-medium" href="/experience/">
+       Experience
+      </a>
+      <a class="text-gray-700 hover:text-carefuse-teal transition-colors duration-200 text-sm font-medium" href="/academics/">
+       Academics
+      </a>
+      <a class="text-gray-700 hover:text-carefuse-teal transition-colors duration-200 text-sm font-medium" href="/campus-involvement/">
+       Campus
+      </a>
+      <a class="text-gray-700 hover:text-carefuse-teal transition-colors duration-200 text-sm font-medium" href="/personal/">
+       Personal
+      </a>
+      <a class="text-gray-700 hover:text-carefuse-teal transition-colors duration-200 text-sm font-medium" href="/recommendations/">
+       Recommendations
+      </a>
+      <a class="text-gray-700 hover:text-carefuse-teal transition-colors duration-200 text-sm font-medium" href="/contact/">
+       Contact
+      </a>
+      <a class="inline-flex items-center space-x-1 bg-carefuse-teal text-white px-4 py-2 rounded-md hover:bg-carefuse-teal/90 transition-colors duration-200 text-sm font-medium" href="/resume/">
+       <svg aria-hidden="true" class="lucide lucide-download w-4 h-4" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+        <path d="M12 15V3">
+        </path>
+        <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4">
+        </path>
+        <path d="m7 10 5 5 5-5">
+        </path>
+       </svg>
+       <span>
+        Resume
+       </span>
+      </a>
+     </div>
+     <div class="md:hidden">
+      <button class="text-gray-700 hover:text-carefuse-teal focus:outline-none focus:text-carefuse-teal">
+       <svg aria-hidden="true" class="lucide lucide-menu w-6 h-6" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+        <path d="M4 5h16">
+        </path>
+        <path d="M4 12h16">
+        </path>
+        <path d="M4 19h16">
+        </path>
+       </svg>
+      </button>
+     </div>
+    </div>
+   </div>
+  </nav>
+  <main class="min-h-screen">
+   <div class="py-20 bg-white">
+    <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+     <div class="text-center mb-16">
+      <div class="flex justify-center mb-6">
+       <img alt="CareFuse" class="w-20 h-20" data-nimg="1" decoding="async" height="80" loading="lazy" src="/images/carefuse_logo.png" style="color:transparent" width="80"/>
+      </div>
+      <h1 class="text-4xl sm:text-5xl font-bold text-carefuse-navy mb-6">
+       CareFuse
+      </h1>
+      <p class="text-xl text-carefuse-gray max-w-3xl mx-auto mb-8">
+       Transparent AI for Hip &amp; Knee Prior Authorization. Per-member clinical predictions with SHAP explanations, built for InterQual/MCG workflows and HL7 FHIR PAS.
+      </p>
+      <a class="inline-flex items-center bg-carefuse-teal text-white px-6 py-3 rounded-lg hover:bg-carefuse-teal/90 transition-colors font-medium" href="https://carefuseai.com" rel="noopener noreferrer" target="_blank">
+       <svg aria-hidden="true" class="lucide lucide-external-link w-4 h-4 mr-2" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+        <path d="M15 3h6v6">
+        </path>
+        <path d="M10 14 21 3">
+        </path>
+        <path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6">
+        </path>
+       </svg>
+       Visit CareFuse Website
+      </a>
+     </div>
+     <section class="mb-20">
+      <div class="text-center mb-12">
+       <h2 class="text-3xl font-bold text-carefuse-navy mb-4">
+        The Perfect Storm: Four Converging Healthcare Forces
+       </h2>
+       <p class="text-lg text-carefuse-gray max-w-4xl mx-auto">
+        The U.S. healthcare system is experiencing unprecedented regulatory convergence that's transforming how knee replacement decisions are made, measured, and governed.
+       </p>
+      </div>
+      <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+       <div class="bg-white rounded-lg border shadow-sm hover:shadow-md duration-200 text-center border-carefuse-teal/20 hover:border-carefuse-teal/50 transition-colors">
+        <div class="p-6 pb-4">
+         <div class="w-16 h-16 bg-carefuse-teal/10 rounded-full flex items-center justify-center mx-auto mb-4">
+          <svg aria-hidden="true" class="lucide lucide-chart-column w-8 h-8 text-carefuse-teal" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+           <path d="M3 3v16a2 2 0 0 0 2 2h16">
+           </path>
+           <path d="M18 17V9">
+           </path>
+           <path d="M13 17V5">
+           </path>
+           <path d="M8 17v-3">
+           </path>
+          </svg>
+         </div>
+         <h3 class="font-semibold mb-2 text-carefuse-navy text-lg">
+          The Accountability Challenge
+         </h3>
+        </div>
+        <div class="px-6 pb-6">
+         <div class="text-3xl font-bold text-carefuse-teal mb-2">
+          24%
+         </div>
+         <p class="text-sm text-carefuse-gray">
+          APU Reduction Penalty for non-compliance with PROMs collection
+         </p>
+        </div>
+       </div>
+       <div class="bg-white rounded-lg border shadow-sm hover:shadow-md duration-200 text-center border-carefuse-teal/20 hover:border-carefuse-teal/50 transition-colors">
+        <div class="p-6 pb-4">
+         <div class="w-16 h-16 bg-carefuse-teal/10 rounded-full flex items-center justify-center mx-auto mb-4">
+          <svg aria-hidden="true" class="lucide lucide-users w-8 h-8 text-carefuse-teal" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+           <path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2">
+           </path>
+           <path d="M16 3.128a4 4 0 0 1 0 7.744">
+           </path>
+           <path d="M22 21v-2a4 4 0 0 0-3-3.87">
+           </path>
+           <circle cx="9" cy="7" r="4">
+           </circle>
+          </svg>
+         </div>
+         <h3 class="font-semibold mb-2 text-carefuse-navy text-lg">
+          The Subjectivity Problem
+         </h3>
+        </div>
+        <div class="px-6 pb-6">
+         <div class="text-3xl font-bold text-carefuse-teal mb-2">
+          High
+         </div>
+         <p class="text-sm text-carefuse-gray">
+          Physician Variation - Significant disagreement on TKA indications
+         </p>
+        </div>
+       </div>
+       <div class="bg-white rounded-lg border shadow-sm hover:shadow-md duration-200 text-center border-carefuse-teal/20 hover:border-carefuse-teal/50 transition-colors">
+        <div class="p-6 pb-4">
+         <div class="w-16 h-16 bg-carefuse-teal/10 rounded-full flex items-center justify-center mx-auto mb-4">
+          <svg aria-hidden="true" class="lucide lucide-shield w-8 h-8 text-carefuse-teal" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+           <path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z">
+           </path>
+          </svg>
+         </div>
+         <h3 class="font-semibold mb-2 text-carefuse-navy text-lg">
+          The Transparency Requirement
+         </h3>
+        </div>
+        <div class="px-6 pb-6">
+         <div class="text-3xl font-bold text-carefuse-teal mb-2">
+          6
+         </div>
+         <p class="text-sm text-carefuse-gray">
+          States with AI Laws requiring physician oversight of AI decisions
+         </p>
+        </div>
+       </div>
+       <div class="bg-white rounded-lg border shadow-sm hover:shadow-md duration-200 text-center border-carefuse-teal/20 hover:border-carefuse-teal/50 transition-colors">
+        <div class="p-6 pb-4">
+         <div class="w-16 h-16 bg-carefuse-teal/10 rounded-full flex items-center justify-center mx-auto mb-4">
+          <svg aria-hidden="true" class="lucide lucide-trending-up w-8 h-8 text-carefuse-teal" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+           <path d="M16 7h6v6">
+           </path>
+           <path d="m22 7-8.5 8.5-5-5L2 17">
+           </path>
+          </svg>
+         </div>
+         <h3 class="font-semibold mb-2 text-carefuse-navy text-lg">
+          The Evidence Gap Problem
+         </h3>
+        </div>
+        <div class="px-6 pb-6">
+         <div class="text-3xl font-bold text-carefuse-teal mb-2">
+          38%
+         </div>
+         <p class="text-sm text-carefuse-gray">
+          TKAs Avoidable with structured conservative care
+         </p>
+        </div>
+       </div>
+      </div>
+     </section>
+     <section class="mb-20">
+      <div class="text-center mb-12">
+       <h2 class="text-3xl font-bold text-carefuse-navy mb-4">
+        CareFuse Solution
+       </h2>
+       <p class="text-lg text-carefuse-gray max-w-4xl mx-auto">
+        Our platform addresses these challenges with transparent, explainable AI that integrates seamlessly with existing healthcare workflows while ensuring regulatory compliance.
+       </p>
+      </div>
+      <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
+       <div class="bg-white rounded-lg border shadow-sm hover:shadow-md duration-200 border-carefuse-teal/20 hover:border-carefuse-teal/50 transition-colors">
+        <div class="p-6 pb-4">
+         <div class="flex items-center space-x-4">
+          <div class="w-12 h-12 bg-carefuse-teal/10 rounded-lg flex items-center justify-center">
+           <svg aria-hidden="true" class="lucide lucide-database w-6 h-6 text-carefuse-teal" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+            <ellipse cx="12" cy="5" rx="9" ry="3">
+            </ellipse>
+            <path d="M3 5V19A9 3 0 0 0 21 19V5">
+            </path>
+            <path d="M3 12A9 3 0 0 0 21 12">
+            </path>
+           </svg>
+          </div>
+          <h3 class="text-xl font-semibold mb-2 text-carefuse-navy">
+           FHIR PAS Ready
+          </h3>
+         </div>
+        </div>
+        <div class="px-6 pb-6">
+         <p class="text-carefuse-gray">
+          Built for Da Vinci PAS workflows and ePA compliance by 2027
+         </p>
+        </div>
+       </div>
+       <div class="bg-white rounded-lg border shadow-sm hover:shadow-md duration-200 border-carefuse-teal/20 hover:border-carefuse-teal/50 transition-colors">
+        <div class="p-6 pb-4">
+         <div class="flex items-center space-x-4">
+          <div class="w-12 h-12 bg-carefuse-teal/10 rounded-lg flex items-center justify-center">
+           <svg aria-hidden="true" class="lucide lucide-brain w-6 h-6 text-carefuse-teal" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+            <path d="M12 18V5">
+            </path>
+            <path d="M15 13a4.17 4.17 0 0 1-3-4 4.17 4.17 0 0 1-3 4">
+            </path>
+            <path d="M17.598 6.5A3 3 0 1 0 12 5a3 3 0 1 0-5.598 1.5">
+            </path>
+            <path d="M17.997 5.125a4 4 0 0 1 2.526 5.77">
+            </path>
+            <path d="M18 18a4 4 0 0 0 2-7.464">
+            </path>
+            <path d="M19.967 17.483A4 4 0 1 1 12 18a4 4 0 1 1-7.967-.517">
+            </path>
+            <path d="M6 18a4 4 0 0 1-2-7.464">
+            </path>
+            <path d="M6.003 5.125a4 4 0 0 0-2.526 5.77">
+            </path>
+           </svg>
+          </div>
+          <h3 class="text-xl font-semibold mb-2 text-carefuse-navy">
+           SHAP Explainable
+          </h3>
+         </div>
+        </div>
+        <div class="px-6 pb-6">
+         <p class="text-carefuse-gray">
+          Transparent AI with per-member clinical explanations
+         </p>
+        </div>
+       </div>
+       <div class="bg-white rounded-lg border shadow-sm hover:shadow-md duration-200 border-carefuse-teal/20 hover:border-carefuse-teal/50 transition-colors">
+        <div class="p-6 pb-4">
+         <div class="flex items-center space-x-4">
+          <div class="w-12 h-12 bg-carefuse-teal/10 rounded-lg flex items-center justify-center">
+           <svg aria-hidden="true" class="lucide lucide-circle-check-big w-6 h-6 text-carefuse-teal" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+            <path d="M21.801 10A10 10 0 1 1 17 3.335">
+            </path>
+            <path d="m9 11 3 3L22 4">
+            </path>
+           </svg>
+          </div>
+          <h3 class="text-xl font-semibold mb-2 text-carefuse-navy">
+           InterQual/MCG Compatible
+          </h3>
+         </div>
+        </div>
+        <div class="px-6 pb-6">
+         <p class="text-carefuse-gray">
+          Seamless integration with existing UM workflows
+         </p>
+        </div>
+       </div>
+       <div class="bg-white rounded-lg border shadow-sm hover:shadow-md duration-200 border-carefuse-teal/20 hover:border-carefuse-teal/50 transition-colors">
+        <div class="p-6 pb-4">
+         <div class="flex items-center space-x-4">
+          <div class="w-12 h-12 bg-carefuse-teal/10 rounded-lg flex items-center justify-center">
+           <svg aria-hidden="true" class="lucide lucide-stethoscope w-6 h-6 text-carefuse-teal" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+            <path d="M11 2v2">
+            </path>
+            <path d="M5 2v2">
+            </path>
+            <path d="M5 3H4a2 2 0 0 0-2 2v4a6 6 0 0 0 12 0V5a2 2 0 0 0-2-2h-1">
+            </path>
+            <path d="M8 15a6 6 0 0 0 12 0v-3">
+            </path>
+            <circle cx="20" cy="10" r="2">
+            </circle>
+           </svg>
+          </div>
+          <h3 class="text-xl font-semibold mb-2 text-carefuse-navy">
+           FDA Compliant
+          </h3>
+         </div>
+        </div>
+        <div class="px-6 pb-6">
+         <p class="text-carefuse-gray">
+          Built under FDA non-device CDS exemption for healthcare compliance
+         </p>
+        </div>
+       </div>
+      </div>
+     </section>
+     <section class="mb-20">
+      <div class="rounded-lg border shadow-sm hover:shadow-md hover:border-gray-300 transition-all duration-200 bg-carefuse-light border-carefuse-teal/20">
+       <div class="p-6 pb-4 text-center">
+        <h3 class="font-semibold mb-2 text-carefuse-navy text-2xl">
+         My Role &amp; Technical Contributions
+        </h3>
+        <p class="leading-relaxed text-carefuse-gray">
+         Co-founder &amp; Machine Learning Lead at CareFuse
+        </p>
+       </div>
+       <div class="px-6 pb-6 space-y-6">
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
+         <div>
+          <h3 class="text-lg font-semibold text-carefuse-navy mb-3">
+           Machine Learning Development
+          </h3>
+          <ul class="space-y-2 text-carefuse-gray">
+           <li class="flex items-start">
+            <svg aria-hidden="true" class="lucide lucide-circle-check-big w-4 h-4 text-carefuse-teal mr-2 mt-1 flex-shrink-0" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+             <path d="M21.801 10A10 10 0 1 1 17 3.335">
+             </path>
+             <path d="m9 11 3 3L22 4">
+             </path>
+            </svg>
+            Developed explainable AI models for TKA outcome prediction
+           </li>
+           <li class="flex items-start">
+            <svg aria-hidden="true" class="lucide lucide-circle-check-big w-4 h-4 text-carefuse-teal mr-2 mt-1 flex-shrink-0" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+             <path d="M21.801 10A10 10 0 1 1 17 3.335">
+             </path>
+             <path d="m9 11 3 3L22 4">
+             </path>
+            </svg>
+            Implemented SHAP explanations for clinical transparency
+           </li>
+           <li class="flex items-start">
+            <svg aria-hidden="true" class="lucide lucide-circle-check-big w-4 h-4 text-carefuse-teal mr-2 mt-1 flex-shrink-0" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+             <path d="M21.801 10A10 10 0 1 1 17 3.335">
+             </path>
+             <path d="m9 11 3 3L22 4">
+             </path>
+            </svg>
+            Achieved ~0.93 AUC with robust calibration techniques
+           </li>
+           <!-- Added highlight bullets per user request -->
+           <li class="flex items-start">
+            <svg aria-hidden="true" class="lucide lucide-circle-check-big w-4 h-4 text-carefuse-teal mr-2 mt-1 flex-shrink-0" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+             <path d="M21.801 10A10 10 0 1 1 17 3.335">
+             </path>
+             <path d="m9 11 3 3L22 4">
+             </path>
+            </svg>
+            Organized a large OAI dataset for internal model development and analysis
+           </li>
+           <li class="flex items-start">
+            <svg aria-hidden="true" class="lucide lucide-circle-check-big w-4 h-4 text-carefuse-teal mr-2 mt-1 flex-shrink-0" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+             <path d="M21.801 10A10 10 0 1 1 17 3.335">
+             </path>
+             <path d="m9 11 3 3L22 4">
+             </path>
+            </svg>
+            Applied propensity weighting for causal robustness
+           </li>
+          </ul>
+         </div>
+         <div>
+          <h3 class="text-lg font-semibold text-carefuse-navy mb-3">
+           Platform &amp; Deployment
+          </h3>
+          <ul class="space-y-2 text-carefuse-gray">
+           <li class="flex items-start">
+            <svg aria-hidden="true" class="lucide lucide-circle-check-big w-4 h-4 text-carefuse-teal mr-2 mt-1 flex-shrink-0" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+             <path d="M21.801 10A10 10 0 1 1 17 3.335">
+             </path>
+             <path d="m9 11 3 3L22 4">
+             </path>
+            </svg>
+            Built FastAPI + Docker deployment infrastructure
+           </li>
+           <li class="flex items-start">
+            <svg aria-hidden="true" class="lucide lucide-circle-check-big w-4 h-4 text-carefuse-teal mr-2 mt-1 flex-shrink-0" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+             <path d="M21.801 10A10 10 0 1 1 17 3.335">
+             </path>
+             <path d="m9 11 3 3L22 4">
+             </path>
+            </svg>
+            Developed dockerized RESTful APIs for model serving and internal tooling
+           </li>
+           <li class="flex items-start">
+            <svg aria-hidden="true" class="lucide lucide-circle-check-big w-4 h-4 text-carefuse-teal mr-2 mt-1 flex-shrink-0" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+             <path d="M21.801 10A10 10 0 1 1 17 3.335">
+             </path>
+             <path d="m9 11 3 3L22 4">
+             </path>
+            </svg>
+            Designed and implemented the company's website and public-facing UI
+           </li>
+           <li class="flex items-start">
+            <svg aria-hidden="true" class="lucide lucide-circle-check-big w-4 h-4 text-carefuse-teal mr-2 mt-1 flex-shrink-0" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+             <path d="M21.801 10A10 10 0 1 1 17 3.335">
+             </path>
+             <path d="m9 11 3 3L22 4">
+             </path>
+            </svg>
+            Designed FHIR R4 and Da Vinci PAS integration
+           </li>
+           <li class="flex items-start">
+            <svg aria-hidden="true" class="lucide lucide-circle-check-big w-4 h-4 text-carefuse-teal mr-2 mt-1 flex-shrink-0" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+             <path d="M21.801 10A10 10 0 1 1 17 3.335">
+             </path>
+             <path d="m9 11 3 3L22 4">
+             </path>
+            </svg>
+            Ensured FDA non-device CDS exemption compliance
+           </li>
+           <li class="flex items-start">
+            <svg aria-hidden="true" class="lucide lucide-circle-check-big w-4 h-4 text-carefuse-teal mr-2 mt-1 flex-shrink-0" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+             <path d="M21.801 10A10 10 0 1 1 17 3.335">
+             </path>
+             <path d="m9 11 3 3L22 4">
+             </path>
+            </svg>
+            Implemented multi-seed holdout validation
+           </li>
+          </ul>
+         </div>
+        </div>
+       </div>
+      </div>
+     </section>
+     <section class="mb-20">
+      <div class="rounded-lg border border-gray-200 shadow-sm hover:shadow-md hover:border-gray-300 transition-all duration-200 bg-gradient-to-br from-carefuse-navy to-carefuse-teal text-white">
+       <div class="p-8 text-center">
+        <h2 class="text-2xl font-bold mb-4">
+         Impact &amp; Vision
+        </h2>
+        <p class="text-lg leading-relaxed mb-6">
+         CareFuse represents my commitment to using AI for patient safety and clinical transparency. By providing explainable predictions and seamless workflow integration, we're helping healthcare providers make evidence-based decisions that prioritize patient outcomes over volume.
+        </p>
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-6 text-center">
+         <div>
+          <div class="text-3xl font-bold mb-2">
+           38%
+          </div>
+          <div class="text-sm opacity-90">
+           Avoidable TKAs with structured care
+          </div>
+         </div>
+         <div>
+          <div class="text-3xl font-bold mb-2">
+           ~0.93
+          </div>
+          <div class="text-sm opacity-90">
+           AUC for outcome prediction
+          </div>
+         </div>
+         <div>
+          <div class="text-3xl font-bold mb-2">
+           100%
+          </div>
+          <div class="text-sm opacity-90">
+           Transparent, explainable decisions
+          </div>
+         </div>
+        </div>
+       </div>
+      </div>
+     </section>
+     <div class="mt-12 text-center" style="margin-bottom:2.25rem;">
+      <a class="inline-flex items-center bg-carefuse-teal text-white px-6 py-3 rounded-lg hover:bg-carefuse-teal/90 transition-colors font-medium" href="/experience/">
+       Next: Experience
+       <svg aria-hidden="true" class="lucide lucide-arrow-right w-4 h-4 ml-2" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+        <path d="M5 12h14">
+        </path>
+        <path d="m12 5 7 7-7 7">
+        </path>
+       </svg>
+      </a>
+     </div>
+    </div>
+   </div>
+  </main>
+  <script>
+   (function(){
+        var btn = document.getElementById('mobile-menu-button');
+        var menu = document.getElementById('mobile-menu');
+        if(!btn || !menu) return;
+        btn.addEventListener('click', function(){
+          var open = menu.classList.toggle('hidden') === false;
+          btn.setAttribute('aria-expanded', open ? 'true' : 'false');
+        });
+      })();
+  </script>
+  <footer class="bg-gray-900 text-white">
+   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+    <div class="grid grid-cols-1 md:grid-cols-3 gap-8">
+     <div>
+      <h3 class="text-lg font-semibold mb-4">
+       Contact
+      </h3>
+      <div class="space-y-3">
+       <div class="flex items-center space-x-3">
+        <svg aria-hidden="true" class="lucide lucide-mail w-5 h-5 text-gray-400" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+         <path d="m22 7-8.991 5.727a2 2 0 0 1-2.009 0L2 7">
+         </path>
+         <rect height="16" rx="2" width="20" x="2" y="4">
+         </rect>
+        </svg>
+        <a class="hover:text-carefuse-teal transition-colors" href="mailto:yuri.braga@carefuseai.com">
+         yuri.braga@carefuseai.com
+        </a>
+       </div>
+       <div class="flex items-center space-x-3">
+        <svg aria-hidden="true" class="lucide lucide-phone w-5 h-5 text-gray-400" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+         <path d="M13.832 16.568a1 1 0 0 0 1.213-.303l.355-.465A2 2 0 0 1 17 15h3a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2A18 18 0 0 1 2 4a2 2 0 0 1 2-2h3a2 2 0 0 1 2 2v3a2 2 0 0 1-.8 1.6l-.468.351a1 1 0 0 0-.292 1.233 14 14 0 0 0 6.392 6.384">
+         </path>
+        </svg>
+        <a class="hover:text-carefuse-teal transition-colors" href="tel:+15409984267">
+         +1 (540) 998-4267
+        </a>
+       </div>
+      </div>
+     </div>
+     <div>
+      <h3 class="text-lg font-semibold mb-4">
+       Quick Links
+      </h3>
+      <div class="space-y-2">
+       <a class="block hover:text-carefuse-teal transition-colors" href="/about/">
+        About
+       </a>
+       <a class="block hover:text-carefuse-teal transition-colors" href="/carefuse/">
+        CareFuse
+       </a>
+       <a class="block hover:text-carefuse-teal transition-colors" href="/academics/">
+        Academics
+       </a>
+       <a class="block hover:text-carefuse-teal transition-colors" href="/contact/">
+        Contact
+       </a>
+       <a class="block hover:text-carefuse-teal transition-colors" href="/resume/">
+        Resume
+       </a>
+      </div>
+     </div>
+     <div>
+      <h3 class="text-lg font-semibold mb-4">
+       Connect
+      </h3>
+      <div class="space-y-2">
+       <a class="flex items-center space-x-2 text-gray-400 hover:text-carefuse-teal transition-colors" href="https://www.linkedin.com/in/yuribraga1/" rel="noopener noreferrer" target="_blank">
+        <svg aria-hidden="true" class="lucide lucide-linkedin w-5 h-5" fill="none" height="24" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" viewbox="0 0 24 24" width="24" xmlns="http://www.w3.org/2000/svg">
+         <path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z">
+         </path>
+         <rect height="12" width="4" x="2" y="9">
+         </rect>
+         <circle cx="4" cy="4" r="2">
+         </circle>
+        </svg>
+        <span>
+         LinkedIn
+        </span>
+       </a>
+       <a class="block text-gray-400 hover:text-vt-orange transition-colors" href="https://carefuseai.com" rel="noopener noreferrer" target="_blank">
+        CareFuse Website
+       </a>
+      </div>
+     </div>
+    </div>
+    <div class="border-t border-gray-800 mt-8 pt-8 text-center">
+     <p class="text-gray-400 text-sm">
+      © 2024 Yuri Braga. All rights reserved. •
+      <span class="ml-1">
+       Built with Next.js and Tailwind CSS
+      </span>
+     </p>
+    </div>
+   </div>
+  </footer>
+  <script async="" src="/_next/static/chunks/webpack-616e068a201ad621.js">
+  </script>
+  <script>
+   (self.__next_f=self.__next_f||[]).push([0]);self.__next_f.push([2,null])
+  </script>
+  <script>
+   self.__next_f.push([1,"1:HL[\"/_next/static/css/28d069147ec3b886.css\",\"style\"]\n"])
+  </script>
+  <script>
+   self.__next_f.push([1,"2:I[2846,[],\"\"]\n4:I[5878,[\"972\",\"static/chunks/972-e6acae3a74adc8b1.js\",\"878\",\"static/chunks/878-a2053ba011a8f515.js\",\"346\",\"static/chunks/app/carefuse/page-af51f567578b7af3.js\"],\"Image\"]\n5:I[2972,[\"972\",\"static/chunks/972-e6acae3a74adc8b1.js\",\"878\",\"static/chunks/878-a2053ba011a8f515.js\",\"346\",\"static/chunks/app/carefuse/page-af51f567578b7af3.js\"],\"\"]\n6:I[4707,[],\"\"]\n7:I[6423,[],\"\"]\n8:I[3064,[\"972\",\"static/chunks/972-e6acae3a74adc8b1.js\",\"878\",\"static/chunks/878-a2053ba011a8f515.js\",\"185\",\"static/chunks/app/layout-96060b751e953699.js\"],\"default\"]\na:I[1060,[],\"\"]\nb:[]\n"])
+  </script>
+  <script>
+   self.__next_f.push([1,"0:[\"$\",\"$L2\",null,{\"buildId\":\"TvnfXHU6nbvB6OIZi7NfN\",\"assetPrefix\":\"\",\"urlParts\":[\"\",\"carefuse\",\"\"],\"initialTree\":[\"\",{\"children\":[\"carefuse\",{\"children\":[\"__PAGE__\",{}]}]},\"$undefined\",\"$undefined\",true],\"initialSeedData\":[\"\",{\"children\":[\"carefuse\",{\"children\":[\"__PAGE__\",{},[[\"$L3\",[\"$\",\"div\",null,{\"className\":\"py-20 bg-white\",\"children\":[\"$\",\"div\",null,{\"className\":\"max-w-7xl mx-auto px-4 sm:px-6 lg:px-8\",\"children\":[[\"$\",\"div\",null,{\"className\":\"text-center mb-16\",\"children\":[[\"$\",\"div\",null,{\"className\":\"flex justify-center mb-6\",\"children\":[\"$\",\"$L4\",null,{\"src\":\"/images/carefuse_logo.png\",\"alt\":\"CareFuse\",\"width\":80,\"height\":80,\"className\":\"w-20 h-20\"}]}],[\"$\",\"h1\",null,{\"className\":\"text-4xl sm:text-5xl font-bold text-carefuse-navy mb-6\",\"children\":\"CareFuse\"}],[\"$\",\"p\",null,{\"className\":\"text-xl text-carefuse-gray max-w-3xl mx-auto mb-8\",\"children\":\"Transparent AI for Hip \u0026 Knee Prior Authorization. Per-member clinical predictions with SHAP explanations, built for InterQual/MCG workflows and HL7 FHIR PAS.\"}],[\"$\",\"a\",null,{\"href\":\"https://carefuseai.com\",\"target\":\"_blank\",\"rel\":\"noopener noreferrer\",\"className\":\"inline-flex items-center bg-carefuse-teal text-white px-6 py-3 rounded-lg hover:bg-carefuse-teal/90 transition-colors font-medium\",\"children\":[[\"$\",\"svg\",null,{\"xmlns\":\"http://www.w3.org/2000/svg\",\"width\":24,\"height\":24,\"viewBox\":\"0 0 24 24\",\"fill\":\"none\",\"stroke\":\"currentColor\",\"strokeWidth\":2,\"strokeLinecap\":\"round\",\"strokeLinejoin\":\"round\",\"className\":\"lucide lucide-external-link w-4 h-4 mr-2\",\"aria-hidden\":\"true\",\"children\":[[\"$\",\"path\",\"1q9fwt\",{\"d\":\"M15 3h6v6\"}],[\"$\",\"path\",\"gplh6r\",{\"d\":\"M10 14 21 3\"}],[\"$\",\"path\",\"a6xqqp\",{\"d\":\"M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6\"}],\"$undefined\"]}],\"Visit CareFuse Website\"]}]]}],[\"$\",\"section\",null,{\"className\":\"mb-20\",\"children\":[[\"$\",\"div\",null,{\"className\":\"text-center mb-12\",\"children\":[[\"$\",\"h2\",null,{\"className\":\"text-3xl font-bold text-carefuse-navy mb-4\",\"children\":\"The Perfect Storm: Four Converging Healthcare Forces\"}],[\"$\",\"p\",null,{\"className\":\"text-lg text-carefuse-gray max-w-4xl mx-auto\",\"children\":\"The U.S. healthcare system is experiencing unprecedented regulatory convergence that's transforming how knee replacement decisions are made, measured, and governed.\"}]]}],[\"$\",\"div\",null,{\"className\":\"grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6\",\"children\":[[\"$\",\"div\",null,{\"className\":\"bg-white rounded-lg border shadow-sm hover:shadow-md duration-200 text-center border-carefuse-teal/20 hover:border-carefuse-teal/50 transition-colors\",\"children\":[[\"$\",\"div\",null,{\"className\":\"p-6 pb-4\",\"children\":[[\"$\",\"div\",null,{\"className\":\"w-16 h-16 bg-carefuse-teal/10 rounded-full flex items-center justify-center mx-auto mb-4\",\"children\":[\"$\",\"svg\",null,{\"xmlns\":\"http://www.w3.org/2000/svg\",\"width\":24,\"height\":24,\"viewBox\":\"0 0 24 24\",\"fill\":\"none\",\"stroke\":\"currentColor\",\"strokeWidth\":2,\"strokeLinecap\":\"round\",\"strokeLinejoin\":\"round\",\"className\":\"lucide lucide-chart-column w-8 h-8 text-carefuse-teal\",\"aria-hidden\":\"true\",\"children\":[[\"$\",\"path\",\"c24i48\",{\"d\":\"M3 3v16a2 2 0 0 0 2 2h16\"}],[\"$\",\"path\",\"2bz60n\",{\"d\":\"M18 17V9\"}],[\"$\",\"path\",\"1frdt8\",{\"d\":\"M13 17V5\"}],[\"$\",\"path\",\"17ska0\",{\"d\":\"M8 17v-3\"}],\"$undefined\"]}]}],[\"$\",\"h3\",null,{\"className\":\"font-semibold mb-2 text-carefuse-navy text-lg\",\"children\":\"The Accountability Challenge\"}]]}],[\"$\",\"div\",null,{\"className\":\"px-6 pb-6\",\"children\":[[\"$\",\"div\",null,{\"className\":\"text-3xl font-bold text-carefuse-teal mb-2\",\"children\":\"24%\"}],[\"$\",\"p\",null,{\"className\":\"text-sm text-carefuse-gray\",\"children\":\"APU Reduction Penalty for non-compliance with PROMs collection\"}]]}]]}],[\"$\",\"div\",null,{\"className\":\"bg-white rounded-lg border shadow-sm hover:shadow-md duration-200 text-center border-carefuse-teal/20 hover:border-carefuse-teal/50 transition-colors\",\"children\":[[\"$\",\"div\",null,{\"className\":\"p-6 pb-4\",\"children\":[[\"$\",\"div\",null,{\"className\":\"w-16 h-16 bg-carefuse-teal/10 rounded-full flex items-center justify-center mx-auto mb-4\",\"children\":[\"$\",\"svg\",null,{\"xmlns\":\"http://www.w3.org/2000/svg\",\"width\":24,\"height\":24,\"viewBox\":\"0 0 24 24\",\"fill\":\"none\",\"stroke\":\"currentColor\",\"strokeWidth\":2,\"strokeLinecap\":\"round\",\"strokeLinejoin\":\"round\",\"className\":\"lucide lucide-users w-8 h-8 text-carefuse-teal\",\"aria-hidden\":\"true\",\"children\":[[\"$\",\"path\",\"1yyitq\",{\"d\":\"M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2\"}],[\"$\",\"path\",\"16gr8j\",{\"d\":\"M16 3.128a4 4 0 0 1 0 7.744\"}],[\"$\",\"path\",\"kshegd\",{\"d\":\"M22 21v-2a4 4 0 0 0-3-3.87\"}],[\"$\",\"circle\",\"nufk8\",{\"cx\":\"9\",\"cy\":\"7\",\"r\":\"4\"}],\"$undefined\"]}]}],[\"$\",\"h3\",null,{\"className\":\"font-semibold mb-2 text-carefuse-navy text-lg\",\"children\":\"The Subjectivity Problem\"}]]}],[\"$\",\"div\",null,{\"className\":\"px-6 pb-6\",\"children\":[[\"$\",\"div\",null,{\"className\":\"text-3xl font-bold text-carefuse-teal mb-2\",\"children\":\"High\"}],[\"$\",\"p\",null,{\"className\":\"text-sm text-carefuse-gray\",\"children\":\"Physician Variation - Significant disagreement on TKA indications\"}]]}]]}],[\"$\",\"div\",null,{\"className\":\"bg-white rounded-lg border shadow-sm hover:shadow-md duration-200 text-center border-carefuse-teal/20 hover:border-carefuse-teal/50 transition-colors\",\"children\":[[\"$\",\"div\",null,{\"className\":\"p-6 pb-4\",\"children\":[[\"$\",\"div\",null,{\"className\":\"w-16 h-16 bg-carefuse-teal/10 rounded-full flex items-center justify-center mx-auto mb-4\",\"children\":[\"$\",\"svg\",null,{\"xmlns\":\"http://www.w3.org/2000/svg\",\"width\":24,\"height\":24,\"viewBox\":\"0 0 24 24\",\"fill\":\"none\",\"stroke\":\"currentColor\",\"strokeWidth\":2,\"strokeLinecap\":\"round\",\"strokeLinejoin\":\"round\",\"className\":\"lucide lucide-shield w-8 h-8 text-carefuse-teal\",\"aria-hidden\":\"true\",\"children\":[[\"$\",\"path\",\"oel41y\",{\"d\":\"M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z\"}],\"$undefined\"]}]}],[\"$\",\"h3\",null,{\"className\":\"font-semibold mb-2 text-carefuse-navy text-lg\",\"children\":\"The Transparency Requirement\"}]]}],[\"$\",\"div\",null,{\"className\":\"px-6 pb-6\",\"children\":[[\"$\",\"div\",null,{\"className\":\"text-3xl font-bold text-carefuse-teal mb-2\",\"children\":\"6\"}],[\"$\",\"p\",null,{\"className\":\"text-sm text-carefuse-gray\",\"children\":\"States with AI Laws requiring physician oversight of AI decisions\"}]]}]]}],[\"$\",\"div\",null,{\"className\":\"bg-white rounded-lg border shadow-sm hover:shadow-md duration-200 text-center border-carefuse-teal/20 hover:border-carefuse-teal/50 transition-colors\",\"children\":[[\"$\",\"div\",null,{\"className\":\"p-6 pb-4\",\"children\":[[\"$\",\"div\",null,{\"className\":\"w-16 h-16 bg-carefuse-teal/10 rounded-full flex items-center justify-center mx-auto mb-4\",\"children\":[\"$\",\"svg\",null,{\"xmlns\":\"http://www.w3.org/2000/svg\",\"width\":24,\"height\":24,\"viewBox\":\"0 0 24 24\",\"fill\":\"none\",\"stroke\":\"currentColor\",\"strokeWidth\":2,\"strokeLinecap\":\"round\",\"strokeLinejoin\":\"round\",\"className\":\"lucide lucide-trending-up w-8 h-8 text-carefuse-teal\",\"aria-hidden\":\"true\",\"children\":[[\"$\",\"path\",\"box55l\",{\"d\":\"M16 7h6v6\"}],[\"$\",\"path\",\"1t1m79\",{\"d\":\"m22 7-8.5 8.5-5-5L2 17\"}],\"$undefined\"]}]}],[\"$\",\"h3\",null,{\"className\":\"font-semibold mb-2 text-carefuse-navy text-lg\",\"children\":\"The Evidence Gap Problem\"}]]}],[\"$\",\"div\",null,{\"className\":\"px-6 pb-6\",\"children\":[[\"$\",\"div\",null,{\"className\":\"text-3xl font-bold text-carefuse-teal mb-2\",\"children\":\"38%\"}],[\"$\",\"p\",null,{\"className\":\"text-sm text-carefuse-gray\",\"children\":\"TKAs Avoidable with structured conservative care\"}]]}]]}]]}]]}],[\"$\",\"section\",null,{\"className\":\"mb-20\",\"children\":[[\"$\",\"div\",null,{\"className\":\"text-center mb-12\",\"children\":[[\"$\",\"h2\",null,{\"className\":\"text-3xl font-bold text-carefuse-navy mb-4\",\"children\":\"CareFuse Solution\"}],[\"$\",\"p\",null,{\"className\":\"text-lg text-carefuse-gray max-w-4xl mx-auto\",\"children\":\"Our platform addresses these challenges with transparent, explainable AI that integrates seamlessly with existing healthcare workflows while ensuring regulatory compliance.\"}]]}],[\"$\",\"div\",null,{\"className\":\"grid grid-cols-1 md:grid-cols-2 gap-8\",\"children\":[[\"$\",\"div\",null,{\"className\":\"bg-white rounded-lg border shadow-sm hover:shadow-md duration-200 border-carefuse-teal/20 hover:border-carefuse-teal/50 transition-colors\",\"children\":[[\"$\",\"div\",null,{\"className\":\"p-6 pb-4\",\"children\":[\"$\",\"div\",null,{\"className\":\"flex items-center space-x-4\",\"children\":[[\"$\",\"div\",null,{\"className\":\"w-12 h-12 bg-carefuse-teal/10 rounded-lg flex items-center justify-center\",\"children\":[\"$\",\"svg\",null,{\"xmlns\":\"http://www.w3.org/2000/svg\",\"width\":24,\"height\":24,\"viewBox\":\"0 0 24 24\",\"fill\":\"none\",\"stroke\":\"currentColor\",\"strokeWidth\":2,\"strokeLinecap\":\"round\",\"strokeLinejoin\":\"round\",\"className\":\"lucide lucide-database w-6 h-6 text-carefuse-teal\",\"aria-hidden\":\"true\",\"children\":[[\"$\",\"ellipse\",\"msslwz\",{\"cx\":\"12\",\"cy\":\"5\",\"rx\":\"9\",\"ry\":\"3\"}],[\"$\",\"path\",\"1wlel7\",{\"d\":\"M3 5V19A9 3 0 0 0 21 19V5\"}],[\"$\",\"path\",\"mv7ke4\",{\"d\":\"M3 12A9 3 0 0 0 21 12\"}],\"$undefined\"]}]}],[\"$\",\"h3\",null,{\"className\":\"text-xl font-semibold mb-2 text-carefuse-navy\",\"children\":\"FHIR PAS Ready\"}]]}]}],[\"$\",\"div\",null,{\"className\":\"px-6 pb-6\",\"children\":[\"$\",\"p\",null,{\"className\":\"text-carefuse-gray\",\"children\":\"Built for Da Vinci PAS workflows and ePA compliance by 2027\"}]}]]}],[\"$\",\"div\",null,{\"className\":\"bg-white rounded-lg border shadow-sm hover:shadow-md duration-200 border-carefuse-teal/20 hover:border-carefuse-teal/50 transition-colors\",\"children\":[[\"$\",\"div\",null,{\"className\":\"p-6 pb-4\",\"children\":[\"$\",\"div\",null,{\"className\":\"flex items-center space-x-4\",\"children\":[[\"$\",\"div\",null,{\"className\":\"w-12 h-12 bg-carefuse-teal/10 rounded-lg flex items-center justify-center\",\"children\":[\"$\",\"svg\",null,{\"xmlns\":\"http://www.w3.org/2000/svg\",\"width\":24,\"height\":24,\"viewBox\":\"0 0 24 24\",\"fill\":\"none\",\"stroke\":\"currentColor\",\"strokeWidth\":2,\"strokeLinecap\":\"round\",\"strokeLinejoin\":\"round\",\"className\":\"lucide lucide-brain w-6 h-6 text-carefuse-teal\",\"aria-hidden\":\"true\",\"children\":[[\"$\",\"path\",\"adv99a\",{\"d\":\"M12 18V5\"}],[\"$\",\"path\",\"1e3is1\",{\"d\":\"M15 13a4.17 4.17 0 0 1-3-4 4.17 4.17 0 0 1-3 4\"}],[\"$\",\"path\",\"1gqd8o\",{\"d\":\"M17.598 6.5A3 3 0 1 0 12 5a3 3 0 1 0-5.598 1.5\"}],[\"$\",\"path\",\"iwvgf7\",{\"d\":\"M17.997 5.125a4 4 0 0 1 2.526 5.77\"}],[\"$\",\"path\",\"efp6ie\",{\"d\":\"M18 18a4 4 0 0 0 2-7.464\"}],[\"$\",\"path\",\"1gq6am\",{\"d\":\"M19.967 17.483A4 4 0 1 1 12 18a4 4 0 1 1-7.967-.517\"}],[\"$\",\"path\",\"k1g0md\",{\"d\":\"M6 18a4 4 0 0 1-2-7.464\"}],[\"$\",\"path\",\"q97ue3\",{\"d\":\"M6.003 5.125a4 4 0 0 0-2.526 5.77\"}],\"$undefined\"]}]}],[\"$\",\"h3\",null,{\"className\":\"text-xl font-semibold mb-2 text-carefuse-navy\",\"children\":\"SHAP Explainable\"}]]}]}],[\"$\",\"div\",null,{\"className\":\"px-6 pb-6\",\"children\":[\"$\",\"p\",null,{\"className\":\"text-carefuse-gray\",\"children\":\"Transparent AI with per-member clinical explanations\"}]}]]}],[\"$\",\"div\",null,{\"className\":\"bg-white rounded-lg border shadow-sm hover:shadow-md duration-200 border-carefuse-teal/20 hover:border-carefuse-teal/50 transition-colors\",\"children\":[[\"$\",\"div\",null,{\"className\":\"p-6 pb-4\",\"children\":[\"$\",\"div\",null,{\"className\":\"flex items-center space-x-4\",\"children\":[[\"$\",\"div\",null,{\"className\":\"w-12 h-12 bg-carefuse-teal/10 rounded-lg flex items-center justify-center\",\"children\":[\"$\",\"svg\",null,{\"xmlns\":\"http://www.w3.org/2000/svg\",\"width\":24,\"height\":24,\"viewBox\":\"0 0 24 24\",\"fill\":\"none\",\"stroke\":\"currentColor\",\"strokeWidth\":2,\"strokeLinecap\":\"round\",\"strokeLinejoin\":\"round\",\"className\":\"lucide lucide-circle-check-big w-6 h-6 text-carefuse-teal\",\"aria-hidden\":\"true\",\"children\":[[\"$\",\"path\",\"yps3ct\",{\"d\":\"M21.801 10A10 10 0 1 1 17 3.335\"}],[\"$\",\"path\",\"1pflzl\",{\"d\":\"m9 11 3 3L22 4\"}],\"$undefined\"]}]}],[\"$\",\"h3\",null,{\"className\":\"text-xl font-semibold mb-2 text-carefuse-navy\",\"children\":\"InterQual/MCG Compatible\"}]]}]}],[\"$\",\"div\",null,{\"className\":\"px-6 pb-6\",\"children\":[\"$\",\"p\",null,{\"className\":\"text-carefuse-gray\",\"children\":\"Seamless integration with existing UM workflows\"}]}]]}],[\"$\",\"div\",null,{\"className\":\"bg-white rounded-lg border shadow-sm hover:shadow-md duration-200 border-carefuse-teal/20 hover:border-carefuse-teal/50 transition-colors\",\"children\":[[\"$\",\"div\",null,{\"className\":\"p-6 pb-4\",\"children\":[\"$\",\"div\",null,{\"className\":\"flex items-center space-x-4\",\"children\":[[\"$\",\"div\",null,{\"className\":\"w-12 h-12 bg-carefuse-teal/10 rounded-lg flex items-center justify-center\",\"children\":[\"$\",\"svg\",null,{\"xmlns\":\"http://www.w3.org/2000/svg\",\"width\":24,\"height\":24,\"viewBox\":\"0 0 24 24\",\"fill\":\"none\",\"stroke\":\"currentColor\",\"strokeWidth\":2,\"strokeLinecap\":\"round\",\"strokeLinejoin\":\"round\",\"className\":\"lucide lucide-stethoscope w-6 h-6 text-carefuse-teal\",\"aria-hidden\":\"true\",\"children\":[[\"$\",\"path\",\"1539x4\",{\"d\":\"M11 2v2\"}],[\"$\",\"path\",\"1yf1q8\",{\"d\":\"M5 2v2\"}],[\"$\",\"path\",\"rb5t3r\",{\"d\":\"M5 3H4a2 2 0 0 0-2 2v4a6 6 0 0 0 12 0V5a2 2 0 0 0-2-2h-1\"}],[\"$\",\"path\",\"x18d4x\",{\"d\":\"M8 15a6 6 0 0 0 12 0v-3\"}],[\"$\",\"circle\",\"ts1r5v\",{\"cx\":\"20\",\"cy\":\"10\",\"r\":\"2\"}],\"$undefined\"]}]}],[\"$\",\"h3\",null,{\"className\":\"text-xl font-semibold mb-2 text-carefuse-navy\",\"children\":\"FDA Compliant\"}]]}]}],[\"$\",\"div\",null,{\"className\":\"px-6 pb-6\",\"children\":[\"$\",\"p\",null,{\"className\":\"text-carefuse-gray\",\"children\":\"Built under FDA non-device CDS exemption for healthcare compliance\"}]}]]}]]}]]}],[\"$\",\"section\",null,{\"className\":\"mb-20\",\"children\":[\"$\",\"div\",null,{\"className\":\"rounded-lg border shadow-sm hover:shadow-md hover:border-gray-300 transition-all duration-200 bg-carefuse-light border-carefuse-teal/20\",\"children\":[[\"$\",\"div\",null,{\"className\":\"p-6 pb-4 text-center\",\"children\":[[\"$\",\"h3\",null,{\"className\":\"font-semibold mb-2 text-carefuse-navy text-2xl\",\"children\":\"My Role \u0026 Technical Contributions\"}],[\"$\",\"p\",null,{\"className\":\"leading-relaxed text-carefuse-gray\",\"children\":\"Co-founder \u0026 Machine Learning Lead at CareFuse\"}]]}],[\"$\",\"div\",null,{\"className\":\"px-6 pb-6 space-y-6\",\"children\":[\"$\",\"div\",null,{\"className\":\"grid grid-cols-1 md:grid-cols-2 gap-8\",\"children\":[[\"$\",\"div\",null,{\"children\":[[\"$\",\"h3\",null,{\"className\":\"text-lg font-semibold text-carefuse-navy mb-3\",\"children\":\"Machine Learning Development\"}],[\"$\",\"ul\",null,{\"className\":\"space-y-2 text-carefuse-gray\",\"children\":[[\"$\",\"li\",null,{\"className\":\"flex items-start\",\"children\":[[\"$\",\"svg\",null,{\"xmlns\":\"http://www.w3.org/2000/svg\",\"width\":24,\"height\":24,\"viewBox\":\"0 0 24 24\",\"fill\":\"none\",\"stroke\":\"currentColor\",\"strokeWidth\":2,\"strokeLinecap\":\"round\",\"strokeLinejoin\":\"round\",\"className\":\"lucide lucide-circle-check-big w-4 h-4 text-carefuse-teal mr-2 mt-1 flex-shrink-0\",\"aria-hidden\":\"true\",\"children\":[[\"$\",\"path\",\"yps3ct\",{\"d\":\"M21.801 10A10 10 0 1 1 17 3.335\"}],[\"$\",\"path\",\"1pflzl\",{\"d\":\"m9 11 3 3L22 4\"}],\"$undefined\"]}],\"Developed explainable AI models for TKA outcome prediction\"]}],[\"$\",\"li\",null,{\"className\":\"flex items-start\",\"children\":[[\"$\",\"svg\",null,{\"xmlns\":\"http://www.w3.org/2000/svg\",\"width\":24,\"height\":24,\"viewBox\":\"0 0 24 24\",\"fill\":\"none\",\"stroke\":\"currentColor\",\"strokeWidth\":2,\"strokeLinecap\":\"round\",\"strokeLinejoin\":\"round\",\"className\":\"lucide lucide-circle-check-big w-4 h-4 text-carefuse-teal mr-2 mt-1 flex-shrink-0\",\"aria-hidden\":\"true\",\"children\":[[\"$\",\"path\",\"yps3ct\",{\"d\":\"M21.801 10A10 10 0 1 1 17 3.335\"}],[\"$\",\"path\",\"1pflzl\",{\"d\":\"m9 11 3 3L22 4\"}],\"$undefined\"]}],\"Implemented SHAP explanations for clinical transparency\"]}],[\"$\",\"li\",null,{\"className\":\"flex items-start\",\"children\":[[\"$\",\"svg\",null,{\"xmlns\":\"http://www.w3.org/2000/svg\",\"width\":24,\"height\":24,\"viewBox\":\"0 0 24 24\",\"fill\":\"none\",\"stroke\":\"currentColor\",\"strokeWidth\":2,\"strokeLinecap\":\"round\",\"strokeLinejoin\":\"round\",\"className\":\"lucide lucide-circle-check-big w-4 h-4 text-carefuse-teal mr-2 mt-1 flex-shrink-0\",\"aria-hidden\":\"true\",\"children\":[[\"$\",\"path\",\"yps3ct\",{\"d\":\"M21.801 10A10 10 0 1 1 17 3.335\"}],[\"$\",\"path\",\"1pflzl\",{\"d\":\"m9 11 3 3L22 4\"}],\"$undefined\"]}],\"Achieved ~0.93 AUC with robust calibration techniques\"]}],[\"$\",\"li\",null,{\"className\":\"flex items-start\",\"children\":[[\"$\",\"svg\",null,{\"xmlns\":\"http://www.w3.org/2000/svg\",\"width\":24,\"height\":24,\"viewBox\":\"0 0 24 24\",\"fill\":\"none\",\"stroke\":\"currentColor\",\"strokeWidth\":2,\"strokeLinecap\":\"round\",\"strokeLinejoin\":\"round\",\"className\":\"lucide lucide-circle-check-big w-4 h-4 text-carefuse-teal mr-2 mt-1 flex-shrink-0\",\"aria-hidden\":\"true\",\"children\":[[\"$\",\"path\",\"yps3ct\",{\"d\":\"M21.801 10A10 10 0 1 1 17 3.335\"}],[\"$\",\"path\",\"1pflzl\",{\"d\":\"m9 11 3 3L22 4\"}],\"$undefined\"]}],\"Applied propensity weighting for causal robustness\"]}]]}]]}],[\"$\",\"div\",null,{\"children\":[[\"$\",\"h3\",null,{\"className\":\"text-lg font-semibold text-carefuse-navy mb-3\",\"children\":\"Platform \u0026 Deployment\"}],[\"$\",\"ul\",null,{\"className\":\"space-y-2 text-carefuse-gray\",\"children\":[[\"$\",\"li\",null,{\"className\":\"flex items-start\",\"children\":[[\"$\",\"svg\",null,{\"xmlns\":\"http://www.w3.org/2000/svg\",\"width\":24,\"height\":24,\"viewBox\":\"0 0 24 24\",\"fill\":\"none\",\"stroke\":\"currentColor\",\"strokeWidth\":2,\"strokeLinecap\":\"round\",\"strokeLinejoin\":\"round\",\"className\":\"lucide lucide-circle-check-big w-4 h-4 text-carefuse-teal mr-2 mt-1 flex-shrink-0\",\"aria-hidden\":\"true\",\"children\":[[\"$\",\"path\",\"yps3ct\",{\"d\":\"M21.801 10A10 10 0 1 1 17 3.335\"}],[\"$\",\"path\",\"1pflzl\",{\"d\":\"m9 11 3 3L22 4\"}],\"$undefined\"]}],\"Built FastAPI + Docker deployment infrastructure\"]}],[\"$\",\"li\",null,{\"className\":\"flex items-start\",\"children\":[[\"$\",\"svg\",null,{\"xmlns\":\"http://www.w3.org/2000/svg\",\"width\":24,\"height\":24,\"viewBox\":\"0 0 24 24\",\"fill\":\"none\",\"stroke\":\"currentColor\",\"strokeWidth\":2,\"strokeLinecap\":\"round\",\"strokeLinejoin\":\"round\",\"className\":\"lucide lucide-circle-check-big w-4 h-4 text-carefuse-teal mr-2 mt-1 flex-shrink-0\",\"aria-hidden\":\"true\",\"children\":[[\"$\",\"path\",\"yps3ct\",{\"d\":\"M21.801 10A10 10 0 1 1 17 3.335\"}],[\"$\",\"path\",\"1pflzl\",{\"d\":\"m9 11 3 3L22 4\"}],\"$undefined\"]}],\"Designed FHIR R4 and Da Vinci PAS integration\"]}],[\"$\",\"li\",null,{\"className\":\"flex items-start\",\"children\":[[\"$\",\"svg\",null,{\"xmlns\":\"http://www.w3.org/2000/svg\",\"width\":24,\"height\":24,\"viewBox\":\"0 0 24 24\",\"fill\":\"none\",\"stroke\":\"currentColor\",\"strokeWidth\":2,\"strokeLinecap\":\"round\",\"strokeLinejoin\":\"round\",\"className\":\"lucide lucide-circle-check-big w-4 h-4 text-carefuse-teal mr-2 mt-1 flex-shrink-0\",\"aria-hidden\":\"true\",\"children\":[[\"$\",\"path\",\"yps3ct\",{\"d\":\"M21.801 10A10 10 0 1 1 17 3.335\"}],[\"$\",\"path\",\"1pflzl\",{\"d\":\"m9 11 3 3L22 4\"}],\"$undefined\"]}],\"Ensured FDA non-device CDS exemption compliance\"]}],[\"$\",\"li\",null,{\"className\":\"flex items-start\",\"children\":[[\"$\",\"svg\",null,{\"xmlns\":\"http://www.w3.org/2000/svg\",\"width\":24,\"height\":24,\"viewBox\":\"0 0 24 24\",\"fill\":\"none\",\"stroke\":\"currentColor\",\"strokeWidth\":2,\"strokeLinecap\":\"round\",\"strokeLinejoin\":\"round\",\"className\":\"lucide lucide-circle-check-big w-4 h-4 text-carefuse-teal mr-2 mt-1 flex-shrink-0\",\"aria-hidden\":\"true\",\"children\":[[\"$\",\"path\",\"yps3ct\",{\"d\":\"M21.801 10A10 10 0 1 1 17 3.335\"}],[\"$\",\"path\",\"1pflzl\",{\"d\":\"m9 11 3 3L22 4\"}],\"$undefined\"]}],\"Implemented multi-seed holdout validation\"]}]]}]]}]]}]}]]}]}],[\"$\",\"section\",null,{\"className\":\"mb-20\",\"children\":[\"$\",\"div\",null,{\"className\":\"rounded-lg border border-gray-200 shadow-sm hover:shadow-md hover:border-gray-300 transition-all duration-200 bg-gradient-to-br from-carefuse-navy to-carefuse-teal text-white\",\"children\":[\"$\",\"div\",null,{\"className\":\"p-8 text-center\",\"children\":[[\"$\",\"h2\",null,{\"className\":\"text-2xl font-bold mb-4\",\"children\":\"Impact \u0026 Vision\"}],[\"$\",\"p\",null,{\"className\":\"text-lg leading-relaxed mb-6\",\"children\":\"CareFuse represents my commitment to using AI for patient safety and clinical transparency. By providing explainable predictions and seamless workflow integration, we're helping healthcare providers make evidence-based decisions that prioritize patient outcomes over volume.\"}],[\"$\",\"div\",null,{\"className\":\"grid grid-cols-1 md:grid-cols-3 gap-6 text-center\",\"children\":[[\"$\",\"div\",null,{\"children\":[[\"$\",\"div\",null,{\"className\":\"text-3xl font-bold mb-2\",\"children\":\"38%\"}],[\"$\",\"div\",null,{\"className\":\"text-sm opacity-90\",\"children\":\"Avoidable TKAs with structured care\"}]]}],[\"$\",\"div\",null,{\"children\":[[\"$\",\"div\",null,{\"className\":\"text-3xl font-bold mb-2\",\"children\":\"~0.93\"}],[\"$\",\"div\",null,{\"className\":\"text-sm opacity-90\",\"children\":\"AUC for outcome prediction\"}]]}],[\"$\",\"div\",null,{\"children\":[[\"$\",\"div\",null,{\"className\":\"text-3xl font-bold mb-2\",\"children\":\"100%\"}],[\"$\",\"div\",null,{\"className\":\"text-sm opacity-90\",\"children\":\"Transparent, explainable decisions\"}]]}]]}]]}]}]}],[\"$\",\"div\",null,{\"className\":\"text-center\",\"children\":[\"$\",\"$L5\",null,{\"href\":\"/experience\",\"className\":\"inline-flex items-center bg-carefuse-teal text-white px-6 py-3 rounded-lg hover:bg-carefuse-teal/90 transition-colors font-medium\",\"children\":[\"Next: Experience\",[\"$\",\"svg\",null,{\"xmlns\":\"http://www.w3.org/2000/svg\",\"width\":24,\"height\":24,\"viewBox\":\"0 0 24 24\",\"fill\":\"none\",\"stroke\":\"currentColor\",\"strokeWidth\":2,\"strokeLinecap\":\"round\",\"strokeLinejoin\":\"round\",\"className\":\"lucide lucide-arrow-right w-4 h-4 ml-2\",\"aria-hidden\":\"true\",\"children\":[[\"$\",\"path\",\"1ays0h\",{\"d\":\"M5 12h14\"}],[\"$\",\"path\",\"xquz4c\",{\"d\":\"m12 5 7 7-7 7\"}],\"$undefined\"]}]]}]}]]}]}],null],null],null]},[null,[\"$\",\"$L6\",null,{\"parallelRouterKey\":\"children\",\"segmentPath\":[\"children\",\"carefuse\",\"children\"],\"error\":\"$undefined\",\"errorStyles\":\"$undefined\",\"errorScripts\":\"$undefined\",\"template\":[\"$\",\"$L7\",null,{}],\"templateStyles\":\"$undefined\",\"templateScripts\":\"$undefined\",\"notFound\":\"$undefined\",\"notFoundStyles\":\"$undefined\"}]],null]},[[[[\"$\",\"link\",\"0\",{\"rel\":\"stylesheet\",\"href\":\"/_next/static/css/28d069147ec3b886.css\",\"precedence\":\"next\",\"crossOrigin\":\"$undefined\"}]],[\"$\",\"html\",null,{\"lang\":\"en\",\"children\":[\"$\",\"body\",null,{\"className\":\"font-sans antialiased\",\"children\":[[\"$\",\"$L8\",null,{}],[\"$\",\"main\",null,{\"className\":\"min-h-screen\",\"children\":[\"$\",\"$L6\",null,{\"parallelRouterKey\":\"children\",\"segmentPath\":[\"children\"],\"error\":\"$undefined\",\"errorStyles\":\"$undefined\",\"errorScripts\":\"$undefined\",\"template\":[\"$\",\"$L7\",null,{}],\"templateStyles\":\"$undefined\",\"templateScripts\":\"$undefined\",\"notFound\":[[\"$\",\"title\",null,{\"children\":\"404: This page could not be found.\"}],[\"$\",\"div\",null,{\"style\":{\"fontFamily\":\"system-ui,\\\"Segoe UI\\\",Roboto,Helvetica,Arial,sans-serif,\\\"Apple Color Emoji\\\",\\\"Segoe UI Emoji\\\"\",\"height\":\"100vh\",\"textAlign\":\"center\",\"display\":\"flex\",\"flexDirection\":\"column\",\"alignItems\":\"center\",\"justifyContent\":\"center\"},\"children\":[\"$\",\"div\",null,{\"children\":[[\"$\",\"style\",null,{\"dangerouslySetInnerHTML\":{\"__html\":\"body{color:#000;background:#fff;margin:0}.next-error-h1{border-right:1px solid rgba(0,0,0,.3)}@media (prefers-color-scheme:dark){body{color:#fff;background:#000}.next-error-h1{border-right:1px solid rgba(255,255,255,.3)}}\"}}],[\"$\",\"h1\",null,{\"className\":\"next-error-h1\",\"style\":{\"display\":\"inline-block\",\"margin\":\"0 20px 0 0\",\"padding\":\"0 23px 0 0\",\"fontSize\":24,\"fontWeight\":500,\"verticalAlign\":\"top\",\"lineHeight\":\"49px\"},\"children\":\"404\"}],[\"$\",\"div\",null,{\"style\":{\"display\":\"inline-block\"},\"children\":[\"$\",\"h2\",null,{\"style\":{\"fontSize\":14,\"fontWeight\":400,\"lineHeight\":\"49px\",\"margin\":0},\"children\":\"This page could not be found.\"}]}]]}]}]],\"notFoundStyles\":[]}]}],[\"$\",\"footer\",null,{\"className\":\"bg-gray-900 text-white\",\"children\":[\"$\",\"div\",null,{\"className\":\"max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12\",\"children\":[[\"$\",\"div\",null,{\"className\":\"grid grid-cols-1 md:grid-cols-3 gap-8\",\"children\":[[\"$\",\"div\",null,{\"children\":[[\"$\",\"h3\",null,{\"className\":\"text-lg font-semibold mb-4\",\"children\":\"Contact\"}],[\"$\",\"div\",null,{\"className\":\"space-y-3\",\"children\":[[\"$\",\"div\",null,{\"className\":\"flex items-center space-x-3\",\"children\":[[\"$\",\"svg\",null,{\"xmlns\":\"http://www.w3.org/2000/svg\",\"width\":24,\"height\":24,\"viewBox\":\"0 0 24 24\",\"fill\":\"none\",\"stroke\":\"currentColor\",\"strokeWidth\":2,\"strokeLinecap\":\"round\",\"strokeLinejoin\":\"round\",\"className\":\"lucide lucide-mail w-5 h-5 text-gray-400\",\"aria-hidden\":\"true\",\"children\":[[\"$\",\"path\",\"132q7q\",{\"d\":\"m22 7-8.991 5.727a2 2 0 0 1-2.009 0L2 7\"}],[\"$\",\"rect\",\"izxlao\",{\"x\":\"2\",\"y\":\"4\",\"width\":\"20\",\"height\":\"16\",\"rx\":\"2\"}],\"$undefined\"]}],[\"$\",\"a\",null,{\"href\":\"mailto:yuri.braga@carefuseai.com\",\"className\":\"hover:text-carefuse-teal transition-colors\",\"children\":\"yuri.braga@carefuseai.com\"}]]}],[\"$\",\"div\",null,{\"className\":\"flex items-center space-x-3\",\"children\":[[\"$\",\"svg\",null,{\"xmlns\":\"http://www.w3.org/2000/svg\",\"width\":24,\"height\":24,\"viewBox\":\"0 0 24 24\",\"fill\":\"none\",\"stroke\":\"currentColor\",\"strokeWidth\":2,\"strokeLinecap\":\"round\",\"strokeLinejoin\":\"round\",\"className\":\"lucide lucide-phone w-5 h-5 text-gray-400\",\"aria-hidden\":\"true\",\"children\":[[\"$\",\"path\",\"9njp5v\",{\"d\":\"M13.832 16.568a1 1 0 0 0 1.213-.303l.355-.465A2 2 0 0 1 17 15h3a2 2 0 0 1 2 2v3a2 2 0 0 1-2 2A18 18 0 0 1 2 4a2 2 0 0 1 2-2h3a2 2 0 0 1 2 2v3a2 2 0 0 1-.8 1.6l-.468.351a1 1 0 0 0-.292 1.233 14 14 0 0 0 6.392 6.384\"}],\"$undefined\"]}],[\"$\",\"a\",null,{\"href\":\"tel:+15409984267\",\"className\":\"hover:text-carefuse-teal transition-colors\",\"children\":\"+1 (540) 998-4267\"}]]}]]}]]}],[\"$\",\"div\",null,{\"children\":[[\"$\",\"h3\",null,{\"className\":\"text-lg font-semibold mb-4\",\"children\":\"Quick Links\"}],[\"$\",\"div\",null,{\"className\":\"space-y-2\",\"children\":[[\"$\",\"$L5\",null,{\"href\":\"/about\",\"className\":\"block hover:text-carefuse-teal transition-colors\",\"children\":\"About\"}],[\"$\",\"$L5\",null,{\"href\":\"/carefuse\",\"className\":\"block hover:text-carefuse-teal transition-colors\",\"children\":\"CareFuse\"}],[\"$\",\"$L5\",null,{\"href\":\"/academics\",\"className\":\"block hover:text-carefuse-teal transition-colors\",\"children\":\"Academics\"}],[\"$\",\"$L5\",null,{\"href\":\"/contact\",\"className\":\"block hover:text-carefuse-teal transition-colors\",\"children\":\"Contact\"}],[\"$\",\"$L5\",null,{\"href\":\"/resume\",\"className\":\"block hover:text-carefuse-teal transition-colors\",\"children\":\"Resume\"}]]}]]}],[\"$\",\"div\",null,{\"children\":[[\"$\",\"h3\",null,{\"className\":\"text-lg font-semibold mb-4\",\"children\":\"Connect\"}],[\"$\",\"div\",null,{\"className\":\"space-y-2\",\"children\":[[\"$\",\"a\",null,{\"href\":\"https://www.linkedin.com/in/yuribraga1/\",\"target\":\"_blank\",\"rel\":\"noopener noreferrer\",\"className\":\"flex items-center space-x-2 text-gray-400 hover:text-carefuse-teal transition-colors\",\"children\":[[\"$\",\"svg\",null,{\"xmlns\":\"http://www.w3.org/2000/svg\",\"width\":24,\"height\":24,\"viewBox\":\"0 0 24 24\",\"fill\":\"none\",\"stroke\":\"currentColor\",\"strokeWidth\":2,\"strokeLinecap\":\"round\",\"strokeLinejoin\":\"round\",\"className\":\"lucide lucide-linkedin w-5 h-5\",\"aria-hidden\":\"true\",\"children\":[[\"$\",\"path\",\"c2jq9f\",{\"d\":\"M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z\"}],[\"$\",\"rect\",\"mk3on5\",{\"width\":\"4\",\"height\":\"12\",\"x\":\"2\",\"y\":\"9\"}],[\"$\",\"circle\",\"bt5ra8\",{\"cx\":\"4\",\"cy\":\"4\",\"r\":\"2\"}],\"$undefined\"]}],[\"$\",\"span\",null,{\"children\":\"LinkedIn\"}]]}],[\"$\",\"a\",null,{\"href\":\"https://carefuseai.com\",\"target\":\"_blank\",\"rel\":\"noopener noreferrer\",\"className\":\"block text-gray-400 hover:text-vt-orange transition-colors\",\"children\":\"CareFuse Website\"}]]}]]}]]}],[\"$\",\"div\",null,{\"className\":\"border-t border-gray-800 mt-8 pt-8 text-center\",\"children\":[\"$\",\"p\",null,{\"className\":\"text-gray-400 text-sm\",\"children\":[\"© 2024 Yuri Braga. All rights reserved. •\",[\"$\",\"span\",null,{\"className\":\"ml-1\",\"children\":\"Built with Next.js and Tailwind CSS\"}]]}]}]]}]}]]}]}]],null],null],\"couldBeIntercepted\":false,\"initialHead\":[null,\"$L9\"],\"globalErrorComponent\":\"$a\",\"missingSlots\":\"$Wb\"}]\n"])
+  </script>
+  <script>
+   self.__next_f.push([1,"9:[[\"$\",\"meta\",\"0\",{\"name\":\"viewport\",\"content\":\"width=device-width, initial-scale=1\"}],[\"$\",\"meta\",\"1\",{\"charSet\":\"utf-8\"}],[\"$\",\"title\",\"2\",{\"children\":\"Yuri Braga - Computer Engineer \u0026 Healthcare AI Researcher\"}],[\"$\",\"meta\",\"3\",{\"name\":\"description\",\"content\":\"Computer Engineer at Virginia Tech specializing in healthcare AI, machine learning for patient safety, and explainable AI models for clinical decision support.\"}],[\"$\",\"meta\",\"4\",{\"name\":\"author\",\"content\":\"Yuri Braga\"}],[\"$\",\"meta\",\"5\",{\"name\":\"keywords\",\"content\":\"machine learning, healthcare AI, explainable AI, surgical outcomes, Total Knee Arthroplasty, MCID, patient safety, Virginia Tech, computer engineering\"}],[\"$\",\"meta\",\"6\",{\"property\":\"og:title\",\"content\":\"Yuri Braga - Computer Engineer \u0026 Healthcare AI Researcher\"}],[\"$\",\"meta\",\"7\",{\"property\":\"og:description\",\"content\":\"Computer Engineer at Virginia Tech specializing in healthcare AI, machine learning for patient safety, and explainable AI models for clinical decision support.\"}],[\"$\",\"meta\",\"8\",{\"property\":\"og:url\",\"content\":\"https://yuribraga.dev/\"}],[\"$\",\"meta\",\"9\",{\"property\":\"og:site_name\",\"content\":\"Yuri Braga Portfolio\"}],[\"$\",\"meta\",\"10\",{\"property\":\"og:type\",\"content\":\"website\"}],[\"$\",\"meta\",\"11\",{\"name\":\"twitter:card\",\"content\":\"summary_large_image\"}],[\"$\",\"meta\",\"12\",{\"name\":\"twitter:title\",\"content\":\"Yuri Braga - Computer Engineer \u0026 Healthcare AI Researcher\"}],[\"$\",\"meta\",\"13\",{\"name\":\"twitter:description\",\"content\":\"Computer Engineer at Virginia Tech specializing in healthcare AI and patient safety.\"}],[\"$\",\"link\",\"14\",{\"rel\":\"icon\",\"href\":\"/favicon.ico\",\"type\":\"image/x-icon\",\"sizes\":\"16x16\"}]]\n3:null\n"])
+  </script>
+ </body>
+</html>
+

--- a/index.html
+++ b/index.html
@@ -361,9 +361,9 @@
 </section>
 </div>
 </main>
-<div class="mt-12 text-center mb-9">
-	<a class="inline-flex items-center bg-carefuse-teal text-white px-6 py-3 rounded-lg hover:bg-carefuse-teal/90 transition-colors font-medium" href="/recommendations/">
-		Next: Recommendations
+<div class="mt-12 text-center" style="margin-bottom:2.25rem;">
+	<a class="inline-flex items-center bg-carefuse-teal text-white px-6 py-3 rounded-lg hover:bg-carefuse-teal/90 transition-colors font-medium" href="/about/">
+		Next: About
 		<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-arrow-right w-4 h-4 ml-2" aria-hidden="true">
 			<path d="M5 12h14"></path>
 			<path d="m12 5 7 7-7 7"></path>


### PR DESCRIPTION
## Summary
- add next-page call-to-action buttons on the home and CareFuse pages with consistent spacing
- remove redundant call-to-action buttons from the About page
- restore the full CareFuse content and pretty-print the page's index.txt snapshot

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df3922d19c8321a113c02cf77e00ea