### PR TITLE
Adjust CTA spacing and academics timeline

### DIFF
--- a/academics/index.html
+++ b/academics/index.html
@@ -161,6 +161,9 @@
                       <p class="text-white/90 text-xl">
                         Virginia Tech
                       </p>
+                      <p class="text-white/80 text-lg">
+                        Aug 2022 – Dec 2025 • Graduating a semester early
+                      </p>
                     </div>
                   </div>
                   <div class="flex-shrink-0">

--- a/index.html
+++ b/index.html
@@ -110,11 +110,7 @@
 </h1>
 <p class="text-xl sm:text-2xl mb-8 text-carefuse-gray">I&#x27;m passionate about optimizing and automating complex tasks to ensure people&#x27;s well-being and improve their quality of life through intelligent systems and data-driven solutions.</p>
 <div class="flex flex-col sm:flex-row gap-4 mb-12">
-<a href="/about" class="inline-flex items-center bg-carefuse-teal text-white px-8 py-4 rounded-lg hover:bg-carefuse-teal/90 transition-colors font-medium text-lg">
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-heart w-5 h-5 mr-2" aria-hidden="true">
-<path d="M2 9.5a5.5 5.5 0 0 1 9.591-3.676.56.56 0 0 0 .818 0A5.49 5.49 0 0 1 22 9.5c0 2.29-1.5 4-3 5.5l-5.492 5.313a2 2 0 0 1-3 .019L5 15c-1.5-1.5-3-3.2-3-5.5">
-</path>
-</svg>About Me</a>
+<a href="/about" class="inline-flex items-center bg-carefuse-teal text-white px-8 py-4 rounded-lg hover:bg-carefuse-teal/90 transition-colors font-medium text-lg">About Me</a>
 <a href="/carefuse" class="inline-flex items-center border-2 border-carefuse-teal text-carefuse-teal px-8 py-4 rounded-lg hover:bg-carefuse-teal hover:text-white transition-colors font-medium text-lg">See CareFuse<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-arrow-right w-5 h-5 ml-2" aria-hidden="true">
 <path d="M5 12h14">
 </path>
@@ -165,6 +161,16 @@
 </div>
 <h3 class="text-lg font-semibold text-carefuse-navy mb-2">ML in Healthcare</h3>
 <p class="text-carefuse-gray text-sm">Explainable AI models for clinical decision support and patient safety</p>
+</div>
+<div class="bg-white rounded-xl shadow-lg border border-gray-100 p-6 hover:shadow-xl transition-shadow">
+<div class="w-12 h-12 bg-purple-500 rounded-lg flex items-center justify-center mb-4">
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-zap w-6 h-6 text-white" aria-hidden="true">
+<path d="M4 14a1 1 0 0 1-.78-1.63l9.9-10.2a.5.5 0 0 1 .86.46l-1.92 6.02A1 1 0 0 0 13 10h7a1 1 0 0 1 .78 1.63l-9.9 10.2a.5.5 0 0 1-.86-.46l1.92-6.02A1 1 0 0 0 11 14z">
+</path>
+</svg>
+</div>
+<h3 class="text-lg font-semibold text-carefuse-navy mb-2">Automation</h3>
+<p class="text-carefuse-gray text-sm">Test automation, robotics, and autonomous system development</p>
 </div>
 <div class="bg-white rounded-xl shadow-lg border border-gray-100 p-6 hover:shadow-xl transition-shadow">
 <div class="w-12 h-12 bg-blue-500 rounded-lg flex items-center justify-center mb-4">
@@ -219,16 +225,6 @@
 </div>
 <h3 class="text-lg font-semibold text-carefuse-navy mb-2">PCB Design</h3>
 <p class="text-carefuse-gray text-sm">Custom Altium PCB design for test fixtures and embedded applications</p>
-</div>
-<div class="bg-white rounded-xl shadow-lg border border-gray-100 p-6 hover:shadow-xl transition-shadow">
-<div class="w-12 h-12 bg-purple-500 rounded-lg flex items-center justify-center mb-4">
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-zap w-6 h-6 text-white" aria-hidden="true">
-<path d="M4 14a1 1 0 0 1-.78-1.63l9.9-10.2a.5.5 0 0 1 .86.46l-1.92 6.02A1 1 0 0 0 13 10h7a1 1 0 0 1 .78 1.63l-9.9 10.2a.5.5 0 0 1-.86-.46l1.92-6.02A1 1 0 0 0 11 14z">
-</path>
-</svg>
-</div>
-<h3 class="text-lg font-semibold text-carefuse-navy mb-2">Automation</h3>
-<p class="text-carefuse-gray text-sm">Test automation, robotics, and autonomous system development</p>
 </div>
 </div>
 </div>
@@ -361,14 +357,21 @@
 </section>
 </div>
 </main>
-<div class="mt-12 text-center" style="margin-bottom:2.25rem;">
-	<a class="inline-flex items-center bg-carefuse-teal text-white px-6 py-3 rounded-lg hover:bg-carefuse-teal/90 transition-colors font-medium" href="/about/">
-		Next: About
-		<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-arrow-right w-4 h-4 ml-2" aria-hidden="true">
-			<path d="M5 12h14"></path>
-			<path d="m12 5 7 7-7 7"></path>
-		</svg>
-	</a>
+<div class="bg-white">
+<div class="mt-16 mb-24 text-center max-w-4xl mx-auto px-4 space-y-6">
+<h2 class="text-2xl sm:text-3xl font-semibold text-carefuse-navy">Ready to learn more about my work?</h2>
+<p class="text-carefuse-gray text-base sm:text-lg">Continue to the About page to explore projects, impact, and the story behind the mission.</p>
+<div class="flex justify-center">
+<a class="inline-flex items-center gap-3 bg-carefuse-teal text-white px-6 py-3 rounded-lg shadow-md hover:bg-carefuse-teal/90 transition-colors font-semibold" href="/about/">
+<span class="text-lg">Next</span>
+<span class="hidden sm:inline text-white/80 text-sm tracking-wide">About Page</span>
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-arrow-right w-4 h-4" aria-hidden="true">
+<path d="M5 12h14"></path>
+<path d="m12 5 7 7-7 7"></path>
+</svg>
+</a>
+</div>
+</div>
 </div>
 <footer class="bg-gray-900 text-white">
 <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">

--- a/personal/index.html
+++ b/personal/index.html
@@ -172,7 +172,7 @@
 </div>
 </div>
 </div>
-<div class="mt-12 text-center">
+<div class="mt-12 mb-16 text-center">
 <a class="inline-flex items-center bg-carefuse-teal text-white px-6 py-3 rounded-lg hover:bg-carefuse-teal/90 transition-colors font-medium" href="/recommendations/">Next: Recommendations<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-arrow-right w-4 h-4 ml-2" aria-hidden="true">
 <path d="M5 12h14"></path>
 <path d="m12 5 7 7-7 7"></path>


### PR DESCRIPTION
## Summary
- remove the heart icon from the home "About Me" button, reorder the skills cards, and add a "Ready to learn more about my work?" next-step section with a dedicated Next button spaced above the footer
- increase the Personal page CTA spacing so the "Next: Recommendations" button sits comfortably above the footer
- update the Academics hero card to include the Aug 2022 – Dec 2025 timeline and note the early graduation

## Testing
- python -m http.server 3000 (manual check)


------
https://chatgpt.com/codex/tasks/task_e_68e1479c752083218c0c7303d2585359