### PR TITLE
Update button styling and add return link

### DIFF
--- a/carefuse/index.html
+++ b/carefuse/index.html
@@ -384,7 +384,7 @@
 </div>
 </section>
 <div class="mt-12 text-center" style="margin-bottom:2.25rem;">
-<a class="inline-flex items-center bg-carefuse-teal text-white px-6 py-3 rounded-lg hover:bg-carefuse-teal/90 transition-colors font-medium" href="/experience/">Next: Experience<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-arrow-right w-4 h-4 ml-2" aria-hidden="true">
+<a class="inline-flex items-center bg-carefuse-navy text-white px-6 py-3 rounded-lg hover:bg-carefuse-navy/90 transition-colors font-medium" href="/experience/">Next: Experience<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="lucide lucide-arrow-right w-4 h-4 ml-2" aria-hidden="true">
 <path d="M5 12h14">
 </path>
 <path d="m12 5 7 7-7 7">

--- a/contact/index.html
+++ b/contact/index.html
@@ -234,6 +234,9 @@
 </div>
 </div>
 </div>
+<div class="mt-10 mb-12 flex justify-center">
+<a class="inline-flex items-center justify-center bg-carefuse-navy text-white px-6 py-3 rounded-lg hover:bg-carefuse-navy/90 transition-colors font-semibold shadow-md" href="/">Return Home</a>
+</div>
 </div>
 </div>
 </div>

--- a/index.html
+++ b/index.html
@@ -84,15 +84,15 @@
             <h1 class="text-4xl sm:text-5xl lg:text-6xl font-bold text-carefuse-navy mb-6">Automation and <span class="text-carefuse-teal">Machine Learning</span></h1>
             <p class="text-xl sm:text-2xl mb-8 text-carefuse-gray">I'm passionate about optimizing and automating complex tasks to ensure people's well-being and improve their quality of life through intelligent systems and data-driven solutions.</p>
             <div class="flex flex-col sm:flex-row gap-4 mb-12">
-              <a href="/about/" class="inline-flex items-center bg-carefuse-teal text-white px-8 py-4 rounded-lg hover:bg-carefuse-teal/90 transition-colors font-medium text-lg">
+              <a href="/about/" class="inline-flex items-center justify-center bg-carefuse-teal text-white px-8 py-4 rounded-lg hover:bg-carefuse-teal/90 transition-colors font-medium text-lg text-center">
                 <span>About Me</span>
               </a>
-              <a href="/carefuse/" class="inline-flex items-center border-2 border-carefuse-teal text-carefuse-teal px-8 py-4 rounded-lg hover:bg-carefuse-teal hover:text-white transition-colors font-medium text-lg">
-                See CareFuse
+              <a href="/carefuse/" class="inline-flex items-center justify-center border-2 border-carefuse-teal text-carefuse-teal px-8 py-4 rounded-lg hover:bg-carefuse-teal hover:text-white transition-colors font-medium text-lg text-center">
+                <span>See CareFuse</span>
                 <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="w-5 h-5 ml-2"><path d="M5 12h14"></path><path d="m12 5 7 7-7 7"></path></svg>
               </a>
-              <a href="/ML_resume.pdf" target="_blank" rel="noopener noreferrer" class="inline-flex items-center bg-carefuse-navy text-white px-8 py-4 rounded-lg hover:bg-carefuse-navy/90 transition-colors font-medium text-lg">
-                Download Resume
+              <a href="/ML_resume.pdf" target="_blank" rel="noopener noreferrer" class="inline-flex items-center justify-center bg-carefuse-navy text-white px-8 py-4 rounded-lg hover:bg-carefuse-navy/90 transition-colors font-medium text-lg text-center">
+                <span>Download Resume</span>
               </a>
             </div>
           </div>
@@ -213,7 +213,7 @@
         <p class="text-carefuse-gray text-base sm:text-lg">Continue to the About page to explore projects, impact, and the story behind the mission.</p>
         <div class="flex justify-center">
           <a class="inline-flex items-center gap-3 bg-carefuse-teal text-white px-6 py-3 rounded-lg shadow-md hover:bg-carefuse-teal/90 transition-colors font-semibold" href="/about/">
-            <span class="text-lg">Next : About</span>
+            <span class="text-lg">Next: About</span>
           </a>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- center the hero call-to-action buttons on the home page and fix the "Next" label spacing
- switch the CareFuse next button to the navy brand color
- add a navy "Return Home" button on the contact page with breathing room above the footer

## Testing
- Not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68e53646724c8321a3254bb9aaa5b371