### PR TITLE
Add VT article links to hero and academics pages

### DIFF
--- a/academics/index.html
+++ b/academics/index.html
@@ -215,6 +215,14 @@
               </div>
             </div>
           </section>
+          <div class="flex justify-center mb-12 px-4">
+            <a
+              href="https://news.vt.edu/articles/2025/12/eng-ece-yuri-braga-2025-cpe.html"
+              class="inline-flex items-center justify-center bg-carefuse-teal text-white px-8 py-4 rounded-lg hover:bg-carefuse-teal/90 transition-colors font-medium text-lg text-center"
+            >
+              <span>VT Article</span>
+            </a>
+          </div>
           <section class="mb-20">
             <h2 class="text-3xl font-bold text-gray-900 mb-12 text-center">
               Research Experience
@@ -440,8 +448,8 @@
               <a class="block hover:text-carefuse-teal transition-colors" href="/contact/">
                 Contact
               </a>
-              <a class="block hover:text-carefuse-teal transition-colors" href="/resume/">
-                Resume
+              <a class="block hover:text-carefuse-teal transition-colors" href="https://news.vt.edu/articles/2025/12/eng-ece-yuri-braga-2025-cpe.html">
+                VT Article
               </a>
             </div>
           </div>

--- a/index.html
+++ b/index.html
@@ -84,8 +84,8 @@
             <h1 class="text-4xl sm:text-5xl lg:text-6xl font-bold text-carefuse-navy mb-6">Automation and <span class="text-carefuse-teal">Machine Learning</span></h1>
             <p class="text-xl sm:text-2xl mb-8 text-carefuse-gray">I'm passionate about optimizing and automating complex tasks to ensure people's well-being and improve their quality of life through intelligent systems and data-driven solutions.</p>
             <div class="flex flex-col sm:flex-row gap-4 mb-12">
-              <a href="/about/" class="inline-flex items-center justify-center bg-carefuse-teal text-white px-8 py-4 rounded-lg hover:bg-carefuse-teal/90 transition-colors font-medium text-lg text-center">
-                <span>About Me</span>
+              <a href="https://news.vt.edu/articles/2025/12/eng-ece-yuri-braga-2025-cpe.html" class="inline-flex items-center justify-center bg-carefuse-teal text-white px-8 py-4 rounded-lg hover:bg-carefuse-teal/90 transition-colors font-medium text-lg text-center">
+                <span>VT Article</span>
               </a>
               <a href="/carefuse/" class="inline-flex items-center justify-center border-2 border-carefuse-teal text-carefuse-teal px-8 py-4 rounded-lg hover:bg-carefuse-teal hover:text-white transition-colors font-medium text-lg text-center">
                 <span>See CareFuse</span>
@@ -243,7 +243,7 @@
             <a class="block hover:text-carefuse-teal transition-colors" href="/carefuse/">CareFuse</a>
             <a class="block hover:text-carefuse-teal transition-colors" href="/academics/">Academics</a>
             <a class="block hover:text-carefuse-teal transition-colors" href="/contact/">Contact</a>
-            <a class="block hover:text-carefuse-teal transition-colors" href="/resume/">Resume</a>
+              <a class="block hover:text-carefuse-teal transition-colors" href="https://news.vt.edu/articles/2025/12/eng-ece-yuri-braga-2025-cpe.html">VT Article</a>
           </div>
         </div>
         <div>


### PR DESCRIPTION
## Summary
- Update the home hero CTA to point to the VT News article
- Add a VT Article button to the Academics page below the degree highlight
- Replace the footer Resume link with the VT Article link

## Testing
- Not run (static HTML changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69398c6c315c8321a3f3c92bf27a2de9)